### PR TITLE
Super duper premium serverside demo pre-recording and demo metadata

### DIFF
--- a/codemp/qcommon/msg.cpp
+++ b/codemp/qcommon/msg.cpp
@@ -78,6 +78,28 @@ void MSG_Init( msg_t *buf, byte *data, int length ) {
 	buf->maxsize = length;
 }
 
+void MSG_ToBuffered(msg_t* src, bufferedMsg_t* dst) {
+	dst->allowoverflow = src->allowoverflow;
+	dst->overflowed = src->overflowed;
+	dst->oob = src->oob;
+	dst->maxsize = src->maxsize;
+	dst->cursize = src->cursize;
+	dst->readcount = src->readcount;
+	dst->bit = src->bit;
+	Com_Memcpy(dst->data, src->data, sizeof(dst->data));
+}
+
+void MSG_FromBuffered(msg_t* dst, bufferedMsg_t* src) {
+	dst->allowoverflow = src->allowoverflow;
+	dst->overflowed = src->overflowed;
+	dst->oob = src->oob;
+	dst->maxsize = src->maxsize;
+	dst->cursize = src->cursize;
+	dst->readcount = src->readcount;
+	dst->bit = src->bit;
+	Com_Memcpy(dst->data, src->data, sizeof(src->data));
+}
+
 void MSG_InitOOB( msg_t *buf, byte *data, int length ) {
 	if (!g_nOverrideChecked)
 	{

--- a/codemp/qcommon/qcommon.h
+++ b/codemp/qcommon/qcommon.h
@@ -51,6 +51,7 @@ void MSG_Clear (msg_t *buf);
 void MSG_WriteData (msg_t *buf, const void *data, int length);
 void MSG_Bitstream( msg_t *buf );
 
+
 struct usercmd_s;
 struct entityState_s;
 struct playerState_s;
@@ -168,6 +169,33 @@ void		Sys_ShowIP(void);
 
 #define MAX_DOWNLOAD_WINDOW			8		// max of eight download frames
 #define MAX_DOWNLOAD_BLKSIZE		2048	// 2048 byte block chunks
+
+
+/*
+* Buffered messages (structs that actually contain the data array) for buffering/prerecording
+*/
+
+typedef struct {
+	qboolean	allowoverflow;	// if false, do a Com_Error
+	qboolean	overflowed;		// set to true if the buffer size failed (with allowoverflow set)
+	qboolean	oob;			// set to true if the buffer size failed (with allowoverflow set)
+	byte	data[MAX_MSGLEN];
+	int		maxsize;
+	int		cursize;
+	int		readcount;
+	int		bit;				// for bitwise reads and writes
+} bufferedMsg_t;
+
+typedef struct {
+	bufferedMsg_t msg;
+	int msgNum; // Message number
+	int time; // We don't want to wait infinitely for old messages to arrive.
+	//qboolean containsFullSnapshot; // Doesn't matter for serverside pre-Recording because we have the keyframes. Comment back in for clientside buffered recording.
+	qboolean isKeyframe; // Is a gamestate message as typical for writing at the start of demos.
+} bufferedMessageContainer_t;
+
+void MSG_ToBuffered(msg_t* src, bufferedMsg_t* dst);
+void MSG_FromBuffered(msg_t* dst, bufferedMsg_t* src);
 
 
 /*

--- a/codemp/qcommon/qcommon.h
+++ b/codemp/qcommon/qcommon.h
@@ -189,7 +189,7 @@ typedef struct {
 typedef struct {
 	bufferedMsg_t msg;
 	int msgNum; // Message number
-	int time; // We don't want to wait infinitely for old messages to arrive.
+	int time; // So we can discard very old buffered messages. Or for clientside recording, so we don't have to wait infinitely for old messages to arrive (which they never may).
 	//qboolean containsFullSnapshot; // Doesn't matter for serverside pre-Recording because we have the keyframes. Comment back in for clientside buffered recording.
 	qboolean isKeyframe; // Is a gamestate message as typical for writing at the start of demos.
 } bufferedMessageContainer_t;

--- a/codemp/qcommon/qcommon.h
+++ b/codemp/qcommon/qcommon.h
@@ -189,6 +189,7 @@ typedef struct {
 typedef struct {
 	bufferedMsg_t msg;
 	int msgNum; // Message number
+	int lastClientCommand; // Need this if we are writing metadata with pre-recording as it is the first thing writen in any message.
 	int time; // So we can discard very old buffered messages. Or for clientside recording, so we don't have to wait infinitely for old messages to arrive (which they never may).
 	//qboolean containsFullSnapshot; // Doesn't matter for serverside pre-Recording because we have the keyframes. Comment back in for clientside buffered recording.
 	qboolean isKeyframe; // Is a gamestate message as typical for writing at the start of demos.

--- a/codemp/server/server.h
+++ b/codemp/server/server.h
@@ -317,11 +317,12 @@ extern	cvar_t	*sv_banFile;
 extern	cvar_t	*sv_maxOOBRate;
 extern	cvar_t	*sv_maxOOBRateIP;
 extern	cvar_t	*sv_autoWhitelist;
-
+#ifdef DEDICATED
 extern	cvar_t	*sv_demoPreRecord;
 extern	cvar_t	*sv_demoPreRecordTime;
 extern	cvar_t	*sv_demoPreRecordKeyframeDistance;
 extern	cvar_t	*sv_demoWriteMeta;
+#endif
 
 extern	cvar_t	*sv_snapShotDuelCull;
 

--- a/codemp/server/server.h
+++ b/codemp/server/server.h
@@ -134,7 +134,7 @@ typedef struct {
 	qboolean	isBot;
 	int			botReliableAcknowledge; // for bots, need to maintain a separate reliableAcknowledge to record server messages into the demo file
 	struct  { 
-		// this is basically the equivalent of the demowaiting and minDeltaFrame values above, except it's for the demo pre-record feature and will be done every sv_demoPreRecordKeyframeDistance milliseconds.
+		// this is basically the equivalent of the demowaiting and minDeltaFrame values above, except it's for the demo pre-record feature and will be done every sv_demoPreRecordKeyframeDistance seconds.
 		qboolean keyframeWaiting;
 		int minDeltaFrame;
 

--- a/codemp/server/server.h
+++ b/codemp/server/server.h
@@ -123,6 +123,7 @@ typedef enum {
 } clientState_t;
 
 
+#ifdef DEDICATED
 // struct to hold demo data for a single demo
 typedef struct {
 	char		demoName[MAX_OSPATH];
@@ -140,10 +141,11 @@ typedef struct {
 		int lastKeyframeTime; // When was the last keyframe (gamestate followed by non-delta frames) saved? If more than sv_demoPreRecordKeyframeDistance, we make a new keyframe.
 	} preRecord;
 } demoInfo_t;
+#endif
 
-
-
+#ifdef DEDICATED
 typedef std::vector<bufferedMessageContainer_t>::iterator demoPreRecordBufferIt;
+#endif
 
 typedef struct client_s {
 	clientState_t	state;
@@ -203,7 +205,9 @@ typedef struct client_s {
 	int				oldServerTime;
 	qboolean		csUpdated[MAX_CONFIGSTRINGS];
 
+#ifdef DEDICATED
 	demoInfo_t		demo;
+#endif
 
 #ifdef DEDICATED
 	qboolean		disableDuelCull;	//set for clients with "Duel see others" option set in cp_pluginDisable on JA+ servers
@@ -303,9 +307,11 @@ extern	cvar_t	*sv_newfloodProtect;
 extern	cvar_t	*sv_lanForceRate;
 extern	cvar_t	*sv_needpass;
 extern	cvar_t	*sv_filterCommands;
+#ifdef DEDICATED
 extern	cvar_t	*sv_autoDemo;
 extern	cvar_t	*sv_autoDemoBots;
 extern	cvar_t	*sv_autoDemoMaxMaps;
+#endif
 extern	cvar_t	*sv_legacyFixes;
 extern	cvar_t	*sv_banFile;
 extern	cvar_t	*sv_maxOOBRate;
@@ -421,6 +427,7 @@ void SV_WriteDownloadToClient( client_t *cl , msg_t *msg );
 // sv_ccmds.c
 //
 void SV_Heartbeat_f( void );
+#ifdef DEDICATED
 void SV_RecordDemo( client_t *cl, char *demoName );
 void SV_StopRecordDemo( client_t *cl );
 void SV_ClearClientDemoMeta( client_t *cl );
@@ -429,6 +436,7 @@ void SV_ClearAllDemoPreRecord( );
 void SV_AutoRecordDemo( client_t *cl );
 void SV_StopAutoRecordDemos();
 void SV_BeginAutoRecordDemos();
+#endif
 
 //
 // sv_snapshot.c

--- a/codemp/server/server.h
+++ b/codemp/server/server.h
@@ -319,6 +319,7 @@ extern	cvar_t	*sv_maxOOBRateIP;
 extern	cvar_t	*sv_autoWhitelist;
 
 extern	cvar_t	*sv_demoPreRecord;
+extern	cvar_t	*sv_demoPreRecordTime;
 extern	cvar_t	*sv_demoPreRecordKeyframeDistance;
 extern	cvar_t	*sv_demoWriteMeta;
 

--- a/codemp/server/server.h
+++ b/codemp/server/server.h
@@ -314,6 +314,7 @@ extern	cvar_t	*sv_autoWhitelist;
 
 extern	cvar_t	*sv_demoPreRecord;
 extern	cvar_t	*sv_demoPreRecordKeyframeDistance;
+extern	cvar_t	*sv_demoWriteMeta;
 
 extern	cvar_t	*sv_snapShotDuelCull;
 
@@ -422,6 +423,9 @@ void SV_WriteDownloadToClient( client_t *cl , msg_t *msg );
 void SV_Heartbeat_f( void );
 void SV_RecordDemo( client_t *cl, char *demoName );
 void SV_StopRecordDemo( client_t *cl );
+void SV_ClearClientDemoMeta( client_t *cl );
+void SV_ClearClientDemoPreRecord( client_t *cl );
+void SV_ClearAllDemoPreRecord( );
 void SV_AutoRecordDemo( client_t *cl );
 void SV_StopAutoRecordDemos();
 void SV_BeginAutoRecordDemos();

--- a/codemp/server/server.h
+++ b/codemp/server/server.h
@@ -132,8 +132,18 @@ typedef struct {
 	fileHandle_t	demofile;
 	qboolean	isBot;
 	int			botReliableAcknowledge; // for bots, need to maintain a separate reliableAcknowledge to record server messages into the demo file
+	struct  { 
+		// this is basically the equivalent of the demowaiting and minDeltaFrame values above, except it's for the demo pre-record feature and will be done every sv_demoPreRecordKeyframeDistance milliseconds.
+		qboolean keyframeWaiting;
+		int minDeltaFrame;
+
+		int lastKeyframeTime; // When was the last keyframe (gamestate followed by non-delta frames) saved? If more than sv_demoPreRecordKeyframeDistance, we make a new keyframe.
+	} preRecord;
 } demoInfo_t;
 
+
+
+typedef std::vector<bufferedMessageContainer_t>::iterator demoPreRecordBufferIt;
 
 typedef struct client_s {
 	clientState_t	state;
@@ -301,6 +311,9 @@ extern	cvar_t	*sv_banFile;
 extern	cvar_t	*sv_maxOOBRate;
 extern	cvar_t	*sv_maxOOBRateIP;
 extern	cvar_t	*sv_autoWhitelist;
+
+extern	cvar_t	*sv_demoPreRecord;
+extern	cvar_t	*sv_demoPreRecordKeyframeDistance;
 
 extern	cvar_t	*sv_snapShotDuelCull;
 

--- a/codemp/server/sv_bot.cpp
+++ b/codemp/server/sv_bot.cpp
@@ -233,9 +233,9 @@ void SV_BotFreeClient( int clientNum ) {
 #ifdef DEDICATED
 	if ( cl->demo.demorecording ) {
 		SV_StopRecordDemo( cl );
-		SV_ClearClientDemoPreRecord( cl );
-		SV_ClearClientDemoMeta(cl);
 	}
+	SV_ClearClientDemoPreRecord(cl);
+	SV_ClearClientDemoMeta(cl);
 #endif
 }
 

--- a/codemp/server/sv_bot.cpp
+++ b/codemp/server/sv_bot.cpp
@@ -232,6 +232,8 @@ void SV_BotFreeClient( int clientNum ) {
 
 	if ( cl->demo.demorecording ) {
 		SV_StopRecordDemo( cl );
+		SV_ClearClientDemoPreRecord( cl );
+		SV_ClearClientDemoMeta(cl);
 	}
 }
 

--- a/codemp/server/sv_bot.cpp
+++ b/codemp/server/sv_bot.cpp
@@ -230,11 +230,13 @@ void SV_BotFreeClient( int clientNum ) {
 		cl->gentity->r.svFlags &= ~SVF_BOT;
 	}
 
+#ifdef DEDICATED
 	if ( cl->demo.demorecording ) {
 		SV_StopRecordDemo( cl );
 		SV_ClearClientDemoPreRecord( cl );
 		SV_ClearClientDemoMeta(cl);
 	}
+#endif
 }
 
 /*

--- a/codemp/server/sv_ccmds.cpp
+++ b/codemp/server/sv_ccmds.cpp
@@ -1803,7 +1803,6 @@ void SV_RecordDemo( client_t *cl, char *demoName ) {
 		int i;
 		ssMeta << "{";
 		ssMeta << "\"wr\":\"EternalJK_Server\""; // Writer (keyword used by other tools too to identify origin of demo)
-		ssMeta << ",\"ost\":" << (int64_t)std::time(nullptr) << ""; // Original start time. When was demo recording started?
 
 		// Go through manually set metadata and add it.
 		for (auto it = demoMetaData[cl - svs.clients].begin(); it != demoMetaData[cl - svs.clients].end(); it++) {
@@ -1863,7 +1862,8 @@ void SV_RecordDemo( client_t *cl, char *demoName ) {
 					if (index == 0 && sv_demoWriteMeta->integer) {
 						// This goes before the first messsage
 
-						ssMeta << ",\"prso\":" << (sv.time-it->time) << ""; // Pre-recording start offset. Offset from start of demo to when the command to start recording was called
+						ssMeta << ",\"ost\":" << ((int64_t)std::time(nullptr) - ((sv.time - it->time)/1000)); // Original start time. When was demo recording started?
+						ssMeta << ",\"prso\":" << (sv.time-it->time); // Pre-recording start offset. Offset from start of demo to when the command to start recording was called
 
 						ssMeta << "}"; // End JSON object
 						SV_WriteEmptyMessageWithMetadata(it->lastClientCommand, cl->demo.demofile,ssMeta.str().c_str(),it->msgNum-1);
@@ -1891,6 +1891,7 @@ void SV_RecordDemo( client_t *cl, char *demoName ) {
 
 	if (sv_demoWriteMeta->integer) {
 		// Write metadata first
+		ssMeta << ",\"ost\":" << (int64_t)std::time(nullptr); // Original start time. When was demo recording started?
 		ssMeta << "}"; // End JSON object
 		SV_WriteEmptyMessageWithMetadata(cl->lastClientCommand, cl->demo.demofile, ssMeta.str().c_str(), cl->netchan.outgoingSequence - 2);
 	}

--- a/codemp/server/sv_ccmds.cpp
+++ b/codemp/server/sv_ccmds.cpp
@@ -1644,7 +1644,7 @@ void SV_ClearClientDemoPreRecord( client_t *cl ) {
 
 	demoPreRecordBuffer[cl - svs.clients].clear();
 	Com_Memset(&cl->demo.preRecord,0,sizeof(cl->demo.preRecord));
-	cl->demo.preRecord.lastKeyframeTime = -sv_demoPreRecordKeyframeDistance->integer * 2; // Make sure that restarting recording will immediately create a keyframe.
+	cl->demo.preRecord.lastKeyframeTime = -(1000*sv_demoPreRecordKeyframeDistance->integer) * 2; // Make sure that restarting recording will immediately create a keyframe.
 }
 
 void SV_ClearAllDemoPreRecord( ) {

--- a/codemp/server/sv_ccmds.cpp
+++ b/codemp/server/sv_ccmds.cpp
@@ -1848,7 +1848,7 @@ void SV_RecordDemo( client_t *cl, char *demoName ) {
 				static byte preRecordBufData[MAX_MSGLEN]; // I make these static so they don't sit on the stack.
 				static msg_t		preRecordMsg;
 
-				if (!it->isKeyframe || index == 0) {
+				if ((!it->isKeyframe || index == 0) && it->msgNum <= cl->netchan.outgoingSequence && it->time <= sv.time) { // Check against outgoing sequence and server time too, *just in case* we ended up with some old messages
 					// We only want a keyframe at the beginning of the demo, none after.
 					Com_Memset(&preRecordMsg, 0, sizeof(msg_t));
 					Com_Memset(&preRecordBufData, 0, sizeof(preRecordBufData));

--- a/codemp/server/sv_client.cpp
+++ b/codemp/server/sv_client.cpp
@@ -330,9 +330,11 @@ gotnewcl:
 
 	SV_UserinfoChanged( newcl );
 
+#ifdef DEDICATED
 	// When a new client connects, we reset the pre-record buffer for this client.
 	SV_ClearClientDemoPreRecord(newcl);
 	SV_ClearClientDemoMeta(newcl);
+#endif
 
 	// send the connect packet to the client
 	NET_OutOfBandPrint( NS_SERVER, from, "connectResponse" );
@@ -411,11 +413,13 @@ void SV_DropClient( client_t *drop, const char *reason ) {
 		drop->state = CS_ZOMBIE;		// become free in a few seconds
 	}
 
+#ifdef DEDICATED
 	if ( drop->demo.demorecording ) {
 		SV_StopRecordDemo( drop );
 		SV_ClearClientDemoPreRecord( drop );
 		SV_ClearClientDemoMeta( drop );
 	}
+#endif
 
 	// if this was the last client on the server, send a heartbeat
 	// to the master so it is known the server is empty
@@ -605,9 +609,11 @@ void SV_ClientEnterWorld( client_t *client, usercmd_t *cmd ) {
 	// call the game begin function
 	GVM_ClientBegin( client - svs.clients );
 
+#ifdef DEDICATED
 	if (sv_autoDemo->integer == 1) { //Bots dont trigger this so whatever
 		SV_BeginAutoRecordDemos();
 	}	
+#endif
 }
 
 /*

--- a/codemp/server/sv_client.cpp
+++ b/codemp/server/sv_client.cpp
@@ -416,9 +416,9 @@ void SV_DropClient( client_t *drop, const char *reason ) {
 #ifdef DEDICATED
 	if ( drop->demo.demorecording ) {
 		SV_StopRecordDemo( drop );
-		SV_ClearClientDemoPreRecord( drop );
-		SV_ClearClientDemoMeta( drop );
 	}
+	SV_ClearClientDemoPreRecord(drop); // Happens on (re)connect too but let's be safe/clean :)
+	SV_ClearClientDemoMeta(drop);
 #endif
 
 	// if this was the last client on the server, send a heartbeat

--- a/codemp/server/sv_client.cpp
+++ b/codemp/server/sv_client.cpp
@@ -128,7 +128,6 @@ SV_DirectConnect
 A "connect" OOB command has been received
 ==================
 */
-extern std::vector<bufferedMessageContainer_t> demoPreRecordBuffer[MAX_CLIENTS];
 void SV_DirectConnect( netadr_t from ) {
 	char		userinfo[MAX_INFO_STRING];
 	int			i;
@@ -332,8 +331,8 @@ gotnewcl:
 	SV_UserinfoChanged( newcl );
 
 	// When a new client connects, we reset the pre-record buffer for this client.
-	demoPreRecordBuffer[clientNum].clear();
-	newcl->demo.preRecord.lastKeyframeTime = -sv_demoPreRecordKeyframeDistance->integer * 2; // Make sure that turning pre-recording on again will immediately cause creation of a keyframe
+	SV_ClearClientDemoPreRecord(newcl);
+	SV_ClearClientDemoMeta(newcl);
 
 	// send the connect packet to the client
 	NET_OutOfBandPrint( NS_SERVER, from, "connectResponse" );
@@ -414,6 +413,8 @@ void SV_DropClient( client_t *drop, const char *reason ) {
 
 	if ( drop->demo.demorecording ) {
 		SV_StopRecordDemo( drop );
+		SV_ClearClientDemoPreRecord( drop );
+		SV_ClearClientDemoMeta( drop );
 	}
 
 	// if this was the last client on the server, send a heartbeat

--- a/codemp/server/sv_client.cpp
+++ b/codemp/server/sv_client.cpp
@@ -128,6 +128,7 @@ SV_DirectConnect
 A "connect" OOB command has been received
 ==================
 */
+extern std::vector<bufferedMessageContainer_t> demoPreRecordBuffer[MAX_CLIENTS];
 void SV_DirectConnect( netadr_t from ) {
 	char		userinfo[MAX_INFO_STRING];
 	int			i;
@@ -329,6 +330,10 @@ gotnewcl:
 	}
 
 	SV_UserinfoChanged( newcl );
+
+	// When a new client connects, we reset the pre-record buffer for this client.
+	demoPreRecordBuffer[clientNum].clear();
+	newcl->demo.preRecord.lastKeyframeTime = -sv_demoPreRecordKeyframeDistance->integer * 2; // Make sure that turning pre-recording on again will immediately cause creation of a keyframe
 
 	// send the connect packet to the client
 	NET_OutOfBandPrint( NS_SERVER, from, "connectResponse" );

--- a/codemp/server/sv_init.cpp
+++ b/codemp/server/sv_init.cpp
@@ -1030,8 +1030,9 @@ void SV_Init (void) {
 	sv_autoWhitelist = Cvar_Get("sv_autoWhitelist", "1", CVAR_ARCHIVE, "Save player IPs to allow them using server during DOS attack" );
 
 #ifdef DEDICATED
-	sv_demoPreRecord = Cvar_Get("sv_demoPreRecord", "15000", CVAR_ARCHIVE, "If not 0, how many milliseconds of past packets should be stored so demos can be retroactively recorded for that duration?");
-	sv_demoPreRecordKeyframeDistance = Cvar_Get("sv_demoPreRecordKeyframeDistance", "5000", CVAR_ARCHIVE, "A demo can only start with a gamestate and full non-delta snapshot. How often should we save such a gamestate message? The shorter the distance, the more precisely the pre-record duration will be kept, but also the higher the RAM usage and regularity of non-delta frames being sent to the clients.");
+	sv_demoPreRecord = Cvar_Get("sv_demoPreRecord", "0", CVAR_ARCHIVE, "Activate server demo pre-recording so demos can be retroactively recorded for duration sv_demoPreRecordTime (seconds)");
+	sv_demoPreRecordTime = Cvar_Get("sv_demoPreRecordTime", "15", CVAR_ARCHIVE, "How many seconds of past packets should be stored for server demo pre-recording?");
+	sv_demoPreRecordKeyframeDistance = Cvar_Get("sv_demoPreRecordKeyframeDistance", "5", CVAR_ARCHIVE, "A demo can only start with a gamestate and full non-delta snapshot. How often should we save such a gamestate message? The shorter the distance, the more precisely the pre-record duration will be kept, but also the higher the RAM usage and regularity of non-delta frames being sent to the clients.");
 	sv_demoWriteMeta = Cvar_Get("sv_demoWriteMeta", "1", CVAR_ARCHIVE, "Enables writing metadata to demos, which can be set by the server/game. This is invisible to normal clients and can be used for storing information about when the demo was recorded, start of the recording, and so on.");
 #endif
 

--- a/codemp/server/sv_init.cpp
+++ b/codemp/server/sv_init.cpp
@@ -456,6 +456,7 @@ void SV_SpawnServer( char *server, qboolean killBots, ForceReload_e eForceReload
 	const char	*p;
 
 	SV_StopAutoRecordDemos();
+	SV_ClearAllDemoPreRecord();
 
 	SV_SendMapChange();
 
@@ -1023,6 +1024,7 @@ void SV_Init (void) {
 
 	sv_demoPreRecord = Cvar_Get("sv_demoPreRecord", "15000", CVAR_ARCHIVE, "If not 0, how many milliseconds of past packets should be stored so demos can be retroactively recorded for that duration?");
 	sv_demoPreRecordKeyframeDistance = Cvar_Get("sv_demoPreRecordKeyframeDistance", "5000", CVAR_ARCHIVE, "A demo can only start with a gamestate and full non-delta snapshot. How often should we save such a gamestate message? The shorter the distance, the more precisely the pre-record duration will be kept, but also the higher the RAM usage and regularity of non-delta frames being sent to the clients.");
+	sv_demoWriteMeta = Cvar_Get("sv_demoWriteMeta", "1", CVAR_ARCHIVE, "Enables writing metadata to demos, which can be set by the server/game. This is invisible to normal clients and can be used for storing information about when the demo was recorded, start of the recording, and so on.");
 
 	sv_snapShotDuelCull = Cvar_Get("sv_snapShotDuelCull", "1", CVAR_NONE, "Snapshot-based duel isolation");
 

--- a/codemp/server/sv_init.cpp
+++ b/codemp/server/sv_init.cpp
@@ -428,8 +428,11 @@ void SV_SendMapChange(void)
 		{
 			if (svs.clients[i].state >= CS_CONNECTED)
 			{
-				if ( svs.clients[i].netchan.remoteAddress.type != NA_BOT ||
-					svs.clients[i].demo.demorecording )
+				if ( svs.clients[i].netchan.remoteAddress.type != NA_BOT 
+#ifdef DEDICATED
+					|| svs.clients[i].demo.demorecording 
+#endif
+					)
 				{
 					SV_SendClientMapChange( &svs.clients[i] ) ;
 				}
@@ -454,9 +457,10 @@ void SV_SpawnServer( char *server, qboolean killBots, ForceReload_e eForceReload
 	qboolean	isBot;
 	char		systemInfo[16384];
 	const char	*p;
-
+#ifdef DEDICATED
 	SV_StopAutoRecordDemos();
 	SV_ClearAllDemoPreRecord();
+#endif
 
 	SV_SendMapChange();
 
@@ -749,6 +753,7 @@ Ghoul2 Insert End
 	}
 	*/
 
+#ifdef DEDICATED
 	for ( client_t *client = svs.clients; client - svs.clients < sv_maxclients->integer; client++) {
 		// bots will not request gamestate, so it must be manually sent
 		// cannot do this above where it says it will because mapname is not set at that time
@@ -758,6 +763,7 @@ Ghoul2 Insert End
 	}
 
 	SV_BeginAutoRecordDemos();
+#endif
 }
 
 
@@ -1005,10 +1011,11 @@ void SV_Init (void) {
 	sv_filterCommands = Cvar_Get( "sv_filterCommands", "2", CVAR_ARCHIVE );
 
 //	sv_debugserver = Cvar_Get ("sv_debugserver", "0", 0);
-
+#ifdef DEDICATED
 	sv_autoDemo = Cvar_Get( "sv_autoDemo", "0", CVAR_ARCHIVE_ND | CVAR_SERVERINFO, "Automatically take server-side demos" );
 	sv_autoDemoBots = Cvar_Get( "sv_autoDemoBots", "0", CVAR_ARCHIVE_ND, "Record server-side demos for bots" );
 	sv_autoDemoMaxMaps = Cvar_Get( "sv_autoDemoMaxMaps", "0", CVAR_ARCHIVE_ND );
+#endif
 
 #ifndef DEDICATED //Default this to off on client to avoid potential mod compatibility issues.
 	sv_legacyFixes = Cvar_Get( "sv_legacyFixes", "0", CVAR_ARCHIVE );
@@ -1022,9 +1029,11 @@ void SV_Init (void) {
 	sv_maxOOBRateIP = Cvar_Get("sv_maxOOBRateIP", "1", CVAR_ARCHIVE, "Maximum rate of handling incoming server commands per IP address" );
 	sv_autoWhitelist = Cvar_Get("sv_autoWhitelist", "1", CVAR_ARCHIVE, "Save player IPs to allow them using server during DOS attack" );
 
+#ifdef DEDICATED
 	sv_demoPreRecord = Cvar_Get("sv_demoPreRecord", "15000", CVAR_ARCHIVE, "If not 0, how many milliseconds of past packets should be stored so demos can be retroactively recorded for that duration?");
 	sv_demoPreRecordKeyframeDistance = Cvar_Get("sv_demoPreRecordKeyframeDistance", "5000", CVAR_ARCHIVE, "A demo can only start with a gamestate and full non-delta snapshot. How often should we save such a gamestate message? The shorter the distance, the more precisely the pre-record duration will be kept, but also the higher the RAM usage and regularity of non-delta frames being sent to the clients.");
 	sv_demoWriteMeta = Cvar_Get("sv_demoWriteMeta", "1", CVAR_ARCHIVE, "Enables writing metadata to demos, which can be set by the server/game. This is invisible to normal clients and can be used for storing information about when the demo was recorded, start of the recording, and so on.");
+#endif
 
 	sv_snapShotDuelCull = Cvar_Get("sv_snapShotDuelCull", "1", CVAR_NONE, "Snapshot-based duel isolation");
 

--- a/codemp/server/sv_init.cpp
+++ b/codemp/server/sv_init.cpp
@@ -1021,6 +1021,9 @@ void SV_Init (void) {
 	sv_maxOOBRateIP = Cvar_Get("sv_maxOOBRateIP", "1", CVAR_ARCHIVE, "Maximum rate of handling incoming server commands per IP address" );
 	sv_autoWhitelist = Cvar_Get("sv_autoWhitelist", "1", CVAR_ARCHIVE, "Save player IPs to allow them using server during DOS attack" );
 
+	sv_demoPreRecord = Cvar_Get("sv_demoPreRecord", "15000", CVAR_ARCHIVE, "If not 0, how many milliseconds of past packets should be stored so demos can be retroactively recorded for that duration?");
+	sv_demoPreRecordKeyframeDistance = Cvar_Get("sv_demoPreRecordKeyframeDistance", "5000", CVAR_ARCHIVE, "A demo can only start with a gamestate and full non-delta snapshot. How often should we save such a gamestate message? The shorter the distance, the more precisely the pre-record duration will be kept, but also the higher the RAM usage and regularity of non-delta frames being sent to the clients.");
+
 	sv_snapShotDuelCull = Cvar_Get("sv_snapShotDuelCull", "1", CVAR_NONE, "Snapshot-based duel isolation");
 
 	sv_pingFix = Cvar_Get("sv_pingFix", "1", CVAR_ARCHIVE_ND, "Improved scoreboard client ping calculation");

--- a/codemp/server/sv_main.cpp
+++ b/codemp/server/sv_main.cpp
@@ -64,9 +64,11 @@ cvar_t	*sv_newfloodProtect;
 cvar_t	*sv_lanForceRate; // dedicated 1 (LAN) server forces local client rates to 99999 (bug #491)
 cvar_t	*sv_needpass;
 cvar_t	*sv_filterCommands; // strict filtering on commands (1: strip ['\r', '\n'], 2: also strip ';')
+#ifdef DEDICATED
 cvar_t	*sv_autoDemo;
 cvar_t	*sv_autoDemoBots;
 cvar_t	*sv_autoDemoMaxMaps;
+#endif
 cvar_t	*sv_legacyFixes;
 cvar_t	*sv_banFile;
 cvar_t	*sv_maxOOBRate;
@@ -551,7 +553,9 @@ void SVC_Info( netadr_t from ) {
 	Info_SetValueForKey( infostring, "wdisable", va("%i", wDisable ) );
 	Info_SetValueForKey( infostring, "fdisable", va("%i", Cvar_VariableIntegerValue( "g_forcePowerDisable" ) ) );
 	//Info_SetValueForKey( infostring, "pure", va("%i", sv_pure->integer ) );
+#ifdef DEDICATED
 	Info_SetValueForKey( infostring, "autodemo", va("%i", sv_autoDemo->integer ) );
+#endif
 
 	if( sv_minPing->integer ) {
 		Info_SetValueForKey( infostring, "minPing", va("%i", sv_minPing->integer) );

--- a/codemp/server/sv_main.cpp
+++ b/codemp/server/sv_main.cpp
@@ -75,10 +75,12 @@ cvar_t	*sv_maxOOBRate;
 cvar_t	*sv_maxOOBRateIP;
 cvar_t	*sv_autoWhitelist;
 
+#ifdef DEDICATED
 cvar_t	*sv_demoPreRecord; // Activate demo pre-recording
 cvar_t	*sv_demoPreRecordTime; // How many seconds of past packets should be stored so demos can be retroactively recorded for that duration?
 cvar_t	*sv_demoPreRecordKeyframeDistance; // A demo can only start with a gamestate and full non-delta snapshot. How often should we save such a gamestate message (in seconds)? The shorter the distance, the more precisely the pre-record duration will be kept.
 cvar_t	*sv_demoWriteMeta; // Enables writing metadata to demos, which can be set by the server/game. This is invisible to normal clients and can be used for storing information about when the demo was recorded, start of the recording, and so on.
+#endif
 
 cvar_t	*sv_snapShotDuelCull;
 

--- a/codemp/server/sv_main.cpp
+++ b/codemp/server/sv_main.cpp
@@ -75,8 +75,9 @@ cvar_t	*sv_maxOOBRate;
 cvar_t	*sv_maxOOBRateIP;
 cvar_t	*sv_autoWhitelist;
 
-cvar_t	*sv_demoPreRecord; // If not 0, how many milliseconds of past packets should be stored so demos can be retroactively recorded for that duration?
-cvar_t	*sv_demoPreRecordKeyframeDistance; // A demo can only start with a gamestate and full non-delta snapshot. How often should we save such a gamestate message? The shorter the distance, the more precisely the pre-record duration will be kept.
+cvar_t	*sv_demoPreRecord; // Activate demo pre-recording
+cvar_t	*sv_demoPreRecordTime; // How many seconds of past packets should be stored so demos can be retroactively recorded for that duration?
+cvar_t	*sv_demoPreRecordKeyframeDistance; // A demo can only start with a gamestate and full non-delta snapshot. How often should we save such a gamestate message (in seconds)? The shorter the distance, the more precisely the pre-record duration will be kept.
 cvar_t	*sv_demoWriteMeta; // Enables writing metadata to demos, which can be set by the server/game. This is invisible to normal clients and can be used for storing information about when the demo was recorded, start of the recording, and so on.
 
 cvar_t	*sv_snapShotDuelCull;

--- a/codemp/server/sv_main.cpp
+++ b/codemp/server/sv_main.cpp
@@ -75,6 +75,7 @@ cvar_t	*sv_autoWhitelist;
 
 cvar_t	*sv_demoPreRecord; // If not 0, how many milliseconds of past packets should be stored so demos can be retroactively recorded for that duration?
 cvar_t	*sv_demoPreRecordKeyframeDistance; // A demo can only start with a gamestate and full non-delta snapshot. How often should we save such a gamestate message? The shorter the distance, the more precisely the pre-record duration will be kept.
+cvar_t	*sv_demoWriteMeta; // Enables writing metadata to demos, which can be set by the server/game. This is invisible to normal clients and can be used for storing information about when the demo was recorded, start of the recording, and so on.
 
 cvar_t	*sv_snapShotDuelCull;
 

--- a/codemp/server/sv_main.cpp
+++ b/codemp/server/sv_main.cpp
@@ -73,6 +73,9 @@ cvar_t	*sv_maxOOBRate;
 cvar_t	*sv_maxOOBRateIP;
 cvar_t	*sv_autoWhitelist;
 
+cvar_t	*sv_demoPreRecord; // If not 0, how many milliseconds of past packets should be stored so demos can be retroactively recorded for that duration?
+cvar_t	*sv_demoPreRecordKeyframeDistance; // A demo can only start with a gamestate and full non-delta snapshot. How often should we save such a gamestate message? The shorter the distance, the more precisely the pre-record duration will be kept.
+
 cvar_t	*sv_snapShotDuelCull;
 
 cvar_t	*sv_pingFix;

--- a/codemp/server/sv_snapshot.cpp
+++ b/codemp/server/sv_snapshot.cpp
@@ -834,7 +834,7 @@ void SV_SendMessageToClient( msg_t *msg, client_t *client ) {
 
 	// Check for whether a new keyframe must be written in pre recording, and if so, do it.
 	if (sv_demoPreRecord->integer) {
-		if (client->demo.preRecord.lastKeyframeTime + sv_demoPreRecordKeyframeDistance->integer < sv.time) {
+		if (client->demo.preRecord.lastKeyframeTime + (1000*sv_demoPreRecordKeyframeDistance->integer) < sv.time) {
 			// Save a keyframe.
 			static byte keyframeBufData[MAX_MSGLEN]; // I make these static so they don't sit on the stack.
 			static msg_t		keyframeMsg;
@@ -861,12 +861,12 @@ void SV_SendMessageToClient( msg_t *msg, client_t *client ) {
 
 		// Clean up pre-record buffer
 		// 
-		// The goal is to always maintain *at least* sv_demoPreRecord milliseconds of buffer. Rather more than less. 
-		// So we find the last keyframe that is older than sv_demoPreRecord milliseconds (or just that old) and then delete everything *before* it.
+		// The goal is to always maintain *at least* sv_demoPreRecordTime seconds of buffer. Rather more than less. 
+		// So we find the last keyframe that is older than sv_demoPreRecordTime seconds (or just that old) and then delete everything *before* it.
 		demoPreRecordBufferIt lastTooOldKeyframe;
 		qboolean lastTooOldKeyframeFound = qfalse;
 		for (demoPreRecordBufferIt it = demoPreRecordBuffer[client - svs.clients].begin(); it != demoPreRecordBuffer[client - svs.clients].end(); it++) {
-			if (it->isKeyframe && (it->time + sv_demoPreRecord->integer) < sv.time) {
+			if (it->isKeyframe && (it->time + (1000*sv_demoPreRecordTime->integer)) < sv.time) {
 				lastTooOldKeyframe = it;
 				lastTooOldKeyframeFound = qtrue;
 			}

--- a/codemp/server/sv_snapshot.cpp
+++ b/codemp/server/sv_snapshot.cpp
@@ -824,10 +824,9 @@ void SV_SendMessageToClient( msg_t *msg, client_t *client ) {
 			client->demo.preRecord.keyframeWaiting = qtrue;
 			client->demo.preRecord.lastKeyframeTime = sv.time;
 		}
-	}
 
-	// Clean up pre-record buffer, whether preRecord is enabled or not (because it might have just been disabled)
-	{
+		// Clean up pre-record buffer
+		// 
 		// The goal is to always maintain *at least* sv_demoPreRecord milliseconds of buffer. Rather more than less. 
 		// So we find the last keyframe that is older than sv_demoPreRecord milliseconds (or just that old) and then delete everything *before* it.
 		demoPreRecordBufferIt lastTooOldKeyframe;
@@ -841,9 +840,13 @@ void SV_SendMessageToClient( msg_t *msg, client_t *client ) {
 		if (lastTooOldKeyframeFound) {
 			// The lastTooOldKeyframe itself won't be erased because .erase()'s second parameter is not inclusive, 
 			// aka it deletes up to that element, but not that element itself.
-			demoPreRecordBuffer[client - svs.clients].erase(demoPreRecordBuffer[client - svs.clients].begin(),lastTooOldKeyframe);
+			demoPreRecordBuffer[client - svs.clients].erase(demoPreRecordBuffer[client - svs.clients].begin(), lastTooOldKeyframe);
 		}
 	}
+	else { // Pre-recording disabled. Clear buffer to prevent unexpected behavior if it is turned back on.
+		demoPreRecordBuffer[client - svs.clients].clear();
+	}
+
 
 	// bots need to have their snapshots built, but
 	// they query them directly without needing to be sent

--- a/codemp/server/sv_snapshot.cpp
+++ b/codemp/server/sv_snapshot.cpp
@@ -26,6 +26,7 @@ along with this program; if not, see <http://www.gnu.org/licenses/>.
 
 
 std::vector<bufferedMessageContainer_t> demoPreRecordBuffer[MAX_CLIENTS];
+std::map<std::string,std::string> demoMetaData[MAX_CLIENTS];
 
 /*
 =============================================================================
@@ -788,6 +789,7 @@ void SV_SendMessageToClient( msg_t *msg, client_t *client ) {
 		Com_Memset(&bmt, 0, sizeof(bufferedMessageContainer_t));
 		MSG_ToBuffered(msg,&bmt.msg);
 		bmt.msgNum = client->netchan.outgoingSequence;
+		bmt.lastClientCommand = client->lastClientCommand;
 		bmt.time = sv.time;
 		bmt.isKeyframe = qfalse; // In theory it might be a gamestate message, but we only call it a keyframe if we ourselves explicitly save a keyframe.
 		demoPreRecordBuffer[client - svs.clients].push_back(bmt);
@@ -818,6 +820,7 @@ void SV_SendMessageToClient( msg_t *msg, client_t *client ) {
 
 			MSG_ToBuffered(&keyframeMsg, &bmt.msg);
 			bmt.msgNum = client->netchan.outgoingSequence; // Yes the keyframe duplicates the messagenum of a message. This is (part of) why we dump only one keyframe at the start of the demo and discard future keyframes
+			bmt.lastClientCommand = client->lastClientCommand;
 			bmt.time = sv.time;
 			bmt.isKeyframe = qtrue; // This is a keyframe (gamestate that will be followed by non-delta frames)
 			demoPreRecordBuffer[client - svs.clients].push_back(bmt);

--- a/codemp/server/sv_snapshot.cpp
+++ b/codemp/server/sv_snapshot.cpp
@@ -845,6 +845,7 @@ void SV_SendMessageToClient( msg_t *msg, client_t *client ) {
 	}
 	else { // Pre-recording disabled. Clear buffer to prevent unexpected behavior if it is turned back on.
 		demoPreRecordBuffer[client - svs.clients].clear();
+		client->demo.preRecord.lastKeyframeTime = -sv_demoPreRecordKeyframeDistance->integer*2; // Make sure that turning pre-recording on again will immediately cause creation of a keyframe
 	}
 
 

--- a/japro_docs.md
+++ b/japro_docs.md
@@ -129,6 +129,8 @@
 	g_raceLog		0//Log to races.log (incase database gets messed up).	
 	g_playerLog		0//Used by /amlookup
 	sv_autoRaceDemo	0 //Requires custom server executable with "svrecord" command.
+	sv_demoPreRecord 15000 // If not 0, how many milliseconds of past packets should be stored so demos can be retroactively recorded for that duration?
+	sv_demoPreRecordKeyframeDistance 5000 // A demo can only start with a gamestate and full non-delta snapshot. How often should we save such a gamestate message? The shorter the distance, the more precisely the pre-record duration will be kept, but also the higher the RAM usage and regularity of non-delta frames being sent to the clients.
 
 #### Bots 
 	bot_nochat			0	

--- a/japro_docs.md
+++ b/japro_docs.md
@@ -129,8 +129,9 @@
 	g_raceLog		0//Log to races.log (incase database gets messed up).	
 	g_playerLog		0//Used by /amlookup
 	sv_autoRaceDemo	0 //Requires custom server executable with "svrecord" command.
-	sv_demoPreRecord 15000 // If not 0, how many milliseconds of past packets should be stored so demos can be retroactively recorded for that duration?
-	sv_demoPreRecordKeyframeDistance 5000 // A demo can only start with a gamestate and full non-delta snapshot. How often should we save such a gamestate message? The shorter the distance, the more precisely the pre-record duration will be kept, but also the higher the RAM usage and regularity of non-delta frames being sent to the clients.
+	sv_demoPreRecord 0 // Activate server demo pre-recording so demos can be retroactively recorded for duration sv_demoPreRecordTime (seconds)
+	sv_demoPreRecordTime 15 // How many seconds of past packets should be stored for pre-recording
+	sv_demoPreRecordKeyframeDistance 5 // A demo can only start with a gamestate and full non-delta snapshot. How often should we save such a gamestate message (in seconds)? The shorter the distance, the more precisely the pre-record duration will be kept, but also the higher the RAM usage and regularity of non-delta frames being sent to the clients.
 	sv_demoWriteMeta 1 // Enables writing metadata to demos, which can be set by the server/game. This is invisible to normal clients and can be used for storing information about when the demo was recorded, start of the recording, and so on.
 
 #### Bots 

--- a/japro_docs.md
+++ b/japro_docs.md
@@ -131,6 +131,7 @@
 	sv_autoRaceDemo	0 //Requires custom server executable with "svrecord" command.
 	sv_demoPreRecord 15000 // If not 0, how many milliseconds of past packets should be stored so demos can be retroactively recorded for that duration?
 	sv_demoPreRecordKeyframeDistance 5000 // A demo can only start with a gamestate and full non-delta snapshot. How often should we save such a gamestate message? The shorter the distance, the more precisely the pre-record duration will be kept, but also the higher the RAM usage and regularity of non-delta frames being sent to the clients.
+	sv_demoWriteMeta 1 // Enables writing metadata to demos, which can be set by the server/game. This is invisible to normal clients and can be used for storing information about when the demo was recorded, start of the recording, and so on.
 
 #### Bots 
 	bot_nochat			0	
@@ -387,6 +388,13 @@
 	amlogout	
 	amlookup	
 
+#### Serverside demo recording
+	svrecord				// Record a server-side demo (including pre-record time if sv_demoPreRecord is not 0 and metadata -default and custom set via svdemometa- if sv_demoWriteMeta is 1).
+	svstoprecord			// Stop recording a server-side demo.
+	svdemometa				// Sets a new metadata entry for server-side demos for one player. Call with clientnum, metakey, "[data]". If data is not provided, the key is cleared. metakey must be letters only, no numbers
+	svdemoclearmeta			// Clears metadata for server-side demos for one player. Call with clientnum.
+	svdemoclearprerecord	// Clears pre-record data for a particular client and forces new keyframe generation. Basically discards previously pre-recorded packets. Call with clientnum.
+	svrenamedemo			// Rename a server-side demo
 
 ## ClientCvars ##
 


### PR DESCRIPTION
Allows pre-recording packets for serverside demos, allowing to record defrag demos without missing start of run.

Also adds ability to add custom metadata to serverside demos, for example for more convenient processing in jamme or more precise cutting at a later point. 

The metadata for the demos works by inserting an empty message at the start of the demo that starts with lastClientCommand (mandatory) and then immediately svc_EOF and then metadata following the svc_EOF, meaning it is invisible to all normal clients.

Metadata is in JSON format, meaning various keys can be set. Some default data is written into the metadata: Unix timestamp of start of the demo, writing application (EternalJK_Server) and pre-record start offset (if using pre-recording) denoting the time difference (in milliseconds) from start of demo to the time the recording was started.

Pre-recording can be enabled via sv_demoPreRecord 1 and demo metadata can be disabled via sv_demoWriteMeta 0. sv_demoPreRecordTime and sv_demoPreRecordKeyframeDistance are time values in seconds, see updates to documentation as well as pastes below. (Edited to reflect new commits)

New commands for game to control the new features:
```
svdemometa				// Sets a new metadata entry for server-side demos for one player. Call with clientnum, metakey, "[data]". If data is not provided, the key is cleared. metakey must be letters only, no numbers
svdemoclearmeta			// Clears metadata for server-side demos for one player. Call with clientnum.
svdemoclearprerecord	// Clears pre-record data for a particular client and forces new keyframe generation. Basically discards previously pre-recorded packets. Call with clientnum.
```

New cvars for server (edited after requested changes):
```
sv_demoPreRecord 0 // Activate server demo pre-recording so demos can be retroactively recorded for duration sv_demoPreRecordTime (seconds)
sv_demoPreRecordTime 15 // How many seconds of past packets should be stored for pre-recording
sv_demoPreRecordKeyframeDistance 5 // A demo can only start with a gamestate and full non-delta snapshot. How often should we save such a gamestate message (in seconds)? The shorter the distance, the more precisely the pre-record duration will be kept, but also the higher the RAM usage and regularity of non-delta frames being sent to the clients.
sv_demoWriteMeta 1 // Enables writing metadata to demos, which can be set by the server/game. This is invisible to normal clients and can be used for storing information about when the demo was recorded, start of the recording, and so on.

```

Edit: Updated after [4371f95 ](https://github.com/taysta/EternalJK/pull/2/commits/4371f956a49edbb99e48b4f24d90698006754608)

Edit 2: Forgot to change description text regarding sv_demoPreRecord.