### PR TITLE
Adjust buffer size when creating shader list

### DIFF
--- a/codemp/rd-rend2/tr_shader.cpp
+++ b/codemp/rd-rend2/tr_shader.cpp
@@ -5044,7 +5044,7 @@ static void ScanAndLoadShaderFiles( void )
 	}
 	Com_Printf("Total shader override files: %d\n", numOShaderFiles);
 	// build single large buffer
-	s_shaderText = (char *)ri.Hunk_Alloc( sum + (numShaderFiles+numOShaderFiles)*2, h_low );
+	s_shaderText = (char *)ri.Hunk_Alloc( sum + numShaderFiles + numOShaderFiles + 1, h_low );
 	s_shaderText[ 0 ] = '\0';
 	textEnd = s_shaderText;
 

--- a/codemp/rd-vanilla/tr_shader.cpp
+++ b/codemp/rd-vanilla/tr_shader.cpp
@@ -4127,7 +4127,7 @@ static void ScanAndLoadShaderFiles( void )
 
 	// build single large buffer
 	Com_Printf("Total shader override files: %d\n", numOShaderFiles);
-	s_shaderText = (char *)ri.Hunk_Alloc( sum + (numShaderFiles+numOShaderFiles)*2, h_low );
+	s_shaderText = (char *)ri.Hunk_Alloc( sum + numShaderFiles + numOShaderFiles + 1, h_low );
 	s_shaderText[ 0 ] = '\0';
 	textEnd = s_shaderText;
 

--- a/codemp/rd-vulkan/tr_shader.cpp
+++ b/codemp/rd-vulkan/tr_shader.cpp
@@ -3039,7 +3039,7 @@ static void ScanAndLoadShaderFiles( void )
 
 	// build single large buffer
 	Com_Printf("Total shader override files: %d\n", numOShaderFiles);
-	s_shaderText = (char*)ri.Hunk_Alloc(sum + (numShaderFiles + numOShaderFiles) * 2, h_low);
+	s_shaderText = (char*)ri.Hunk_Alloc(sum + numShaderFiles + numOShaderFiles + 1, h_low);
 	s_shaderText[0] = '\0';
 	textEnd = s_shaderText;
 


### PR DESCRIPTION
Lets not allocate a buffer bigger than we need to for the shaders, +1 make sufficent space for the null terminator.