### PR TITLE
Git tag and hash

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -324,17 +324,27 @@ endif()
 
 # Current Git tag/version
 # ideally we would separate the hash suffix into its own variable, but sed is not available everywhere
-execute_process(
-	COMMAND "git" "describe" "--tag"
-	WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}
-	OUTPUT_VARIABLE GIT_TAG
-	RESULT_VARIABLE GIT_TAG_ERROR
-	OUTPUT_STRIP_TRAILING_WHITESPACE)
-if(GIT_TAG_ERROR AND NOT GIT_TAG_ERROR EQUAL 0)
-	message(WARNING "Unable to determine Git tag")
+
+# Check for Git on the system
+find_package(Git QUIET)
+if (NOT GIT_FOUND)
+	message(WARNING "Git not found!")
 	set(GIT_TAG vUNKNOWN)
+else()
+	#Get git tag
+	execute_process(
+		COMMAND "git" "describe" "--tag"
+		WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}
+		OUTPUT_VARIABLE GIT_TAG
+		RESULT_VARIABLE GIT_TAG_ERROR
+		OUTPUT_STRIP_TRAILING_WHITESPACE)
+	if(GIT_TAG_ERROR AND NOT GIT_TAG_ERROR EQUAL 0)
+		message(WARNING "Unable to determine Git tag")
+		set(GIT_TAG vUNKNOWN)
+	else()
+		message(STATUS "Git tag is ${GIT_TAG}")
+	endif()
 endif()
-message(STATUS "Git tag is ${GIT_TAG}")
 
 configure_file(shared/qcommon/q_version.h.in shared/qcommon/q_version.h @ONLY)
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -322,10 +322,7 @@ else()
 	message(STATUS "SOURCE_DATE_EPOCH is set ($ENV{SOURCE_DATE_EPOCH}): SOURCE_DATE set to \"${SOURCE_DATE}\"")
 endif()
 
-# Current Git tag/version
-# ideally we would separate the hash suffix into its own variable, but sed is not available everywhere
-
-# Check for Git on the system
+#Check for Git on the system
 find_package(Git QUIET)
 if (NOT GIT_FOUND)
 	message(WARNING "Git not found!")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -330,19 +330,36 @@ find_package(Git QUIET)
 if (NOT GIT_FOUND)
 	message(WARNING "Git not found!")
 	set(GIT_TAG vUNKNOWN)
+	set(GIT_HASH vUNKNOWN)
 else()
 	#Get git tag
 	execute_process(
-		COMMAND "git" "describe" "--tag"
+		COMMAND "git" "describe" "--tags" "--abbrev=0"
 		WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}
 		OUTPUT_VARIABLE GIT_TAG
 		RESULT_VARIABLE GIT_TAG_ERROR
 		OUTPUT_STRIP_TRAILING_WHITESPACE)
+
 	if(GIT_TAG_ERROR AND NOT GIT_TAG_ERROR EQUAL 0)
 		message(WARNING "Unable to determine Git tag")
 		set(GIT_TAG vUNKNOWN)
 	else()
 		message(STATUS "Git tag is ${GIT_TAG}")
+	endif()
+
+	#Get Git commit short hash
+	execute_process(
+		COMMAND "git" "rev-parse" "--short" "HEAD"
+		WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}
+		OUTPUT_VARIABLE GIT_HASH
+		RESULT_VARIABLE GIT_HASH_ERROR
+		OUTPUT_STRIP_TRAILING_WHITESPACE)
+
+	if(GIT_HASH_ERROR AND NOT GIT_HASH_ERROR EQUAL 0)
+		message(WARNING "Unable to determine Git hash")
+		set(GIT_HASH vUNKNOWN)
+	else()
+		message(STATUS "Git hash is ${GIT_HASH}")
 	endif()
 endif()
 

--- a/codemp/CMakeLists.txt
+++ b/codemp/CMakeLists.txt
@@ -23,6 +23,16 @@ endif(NOT InOpenJK)
 
 set(MPSharedDefines ${SharedDefines})
 
+if (GIT_FOUND)
+	if (WIN32)
+		add_custom_target(GET_GIT_TAG_AND_HASH
+		COMMAND cmd /c "${CMAKE_SOURCE_DIR}/scripts/header/update_header.bat" "${CMAKE_BINARY_DIR}/shared/qcommon/q_version.h")
+	elseif(UNIX OR APPLE)
+		add_custom_target(GET_GIT_TAG_AND_HASH
+		COMMAND "${CMAKE_SOURCE_DIR}/scripts/header/update_header.sh" "${CMAKE_BINARY_DIR}/shared/qcommon/q_version.h")
+	endif()
+endif()	
+
 #    Add Game Project
 if(BuildMPGame)
 	add_subdirectory("${MPDir}/game")
@@ -47,7 +57,6 @@ endif(BuildMPRdVanilla)
 if(BuildMPRdVulkan)
 	add_subdirectory("${MPDir}/rd-vulkan")
 endif(BuildMPRdVulkan)
-
 
 #	Add rend2 JKA Renderer Project
 if(BuildMPRend2)
@@ -647,6 +656,10 @@ if(BuildMPEngine)
 	set_target_properties(${MPEngine} PROPERTIES INCLUDE_DIRECTORIES "${MPEngineIncludeDirectories}")
 	set_target_properties(${MPEngine} PROPERTIES PROJECT_LABEL "MP Client")
 	target_link_libraries(${MPEngine} ${MPEngineLibraries})
+
+	if (GIT_FOUND)
+		add_dependencies(${MPEngine} GET_GIT_TAG_AND_HASH)
+	endif()
 endif(BuildMPEngine)
 
 #        Dedicated Server (Engine) (jampded.exe)
@@ -739,6 +752,10 @@ if(BuildMPDed)
 	set_target_properties(${MPDed} PROPERTIES INCLUDE_DIRECTORIES "${MPDedIncludeDirectories}")
 	set_target_properties(${MPDed} PROPERTIES PROJECT_LABEL "MP Dedicated Server")
 	target_link_libraries(${MPDed} ${MPDedLibraries})
+
+	if (GIT_FOUND)
+		add_dependencies(${MPDed} GET_GIT_TAG_AND_HASH)
+	endif()
 endif(BuildMPDed)
 
 include(InstallZIP)

--- a/codemp/cgame/CMakeLists.txt
+++ b/codemp/cgame/CMakeLists.txt
@@ -180,7 +180,12 @@ set_property(TARGET ${MPCGame} APPEND PROPERTY COMPILE_OPTIONS ${OPENJK_VISIBILI
 
 set_target_properties(${MPCGame} PROPERTIES INCLUDE_DIRECTORIES "${MPCGameIncludeDirectories}")
 set_target_properties(${MPCGame} PROPERTIES PROJECT_LABEL "MP Client Game Library")
+
 # no libraries used
 if(MPCGameLibraries)
 	target_link_libraries(${MPCGame} ${MPCGameLibraries})
+	
+	if (GIT_FOUND)
+		add_dependencies(${MPCGame} GET_GIT_TAG_AND_HASH)
+	endif()
 endif(MPCGameLibraries)

--- a/codemp/game/CMakeLists.txt
+++ b/codemp/game/CMakeLists.txt
@@ -245,4 +245,8 @@ set_target_properties(${MPGame} PROPERTIES PROJECT_LABEL "MP Game Library")
 # no libraries used
 if(MPGameLibraries)
 	target_link_libraries(${MPGame} ${MPGameLibraries})
+
+	if (GIT_FOUND)
+		add_dependencies(${MPGame} GET_GIT_TAG_AND_HASH)
+	endif()
 endif(MPGameLibraries)

--- a/codemp/qcommon/game_version.h
+++ b/codemp/qcommon/game_version.h
@@ -38,7 +38,7 @@ along with this program; if not, see <http://www.gnu.org/licenses/>.
 #define VERSION_STRING_DOTTED XSTRING(VERSION_MAJOR_RELEASE) "." XSTRING(VERSION_MINOR_RELEASE) "." XSTRING(VERSION_EXTERNAL_BUILD) "." XSTRING(VERSION_INTERNAL_BUILD) // "a.b.c.d"
 
 #if defined(_DEBUG)
-	#define	JK_VERSION		"(debug)EternalJK: " GIT_TAG
+	#define	JK_VERSION		"(debug)EternalJK: " GIT_TAG"-"GIT_HASH
 	#define JK_VERSION_OLD	"(debug)JAmp: v" VERSION_STRING_DOTTED
 #elif defined (TOURNAMENT_CLIENT)
 	#define JK_VERSION		"EternalJK: Tournament Client" GIT_TAG

--- a/codemp/qcommon/game_version.h
+++ b/codemp/qcommon/game_version.h
@@ -38,12 +38,12 @@ along with this program; if not, see <http://www.gnu.org/licenses/>.
 #define VERSION_STRING_DOTTED XSTRING(VERSION_MAJOR_RELEASE) "." XSTRING(VERSION_MINOR_RELEASE) "." XSTRING(VERSION_EXTERNAL_BUILD) "." XSTRING(VERSION_INTERNAL_BUILD) // "a.b.c.d"
 
 #if defined(_DEBUG)
-	#define	JK_VERSION		"(debug)EternalJK: " GIT_TAG"-"GIT_HASH
+	#define	JK_VERSION		"(debug)EternalJK: " GIT_TAG "-" GIT_HASH
 	#define JK_VERSION_OLD	"(debug)JAmp: v" VERSION_STRING_DOTTED
 #elif defined (TOURNAMENT_CLIENT)
-	#define JK_VERSION		"EternalJK: Tournament Client" GIT_TAG
+	#define JK_VERSION		"EternalJK: Tournament Client: " GIT_TAG "-" GIT_HASH
 	#define JK_VERSION_OLD	"JAmp: v" VERSION_STRING_DOTTED
 #else
-	#define	JK_VERSION		"EternalJK: " GIT_TAG
+	#define	JK_VERSION		"EternalJK: " GIT_TAG "-" GIT_HASH
 	#define JK_VERSION_OLD	"JAmp: v" VERSION_STRING_DOTTED
 #endif

--- a/codemp/ui/CMakeLists.txt
+++ b/codemp/ui/CMakeLists.txt
@@ -128,4 +128,8 @@ set_target_properties(${MPUI} PROPERTIES PROJECT_LABEL "MP UI Library")
 # no libraries used
 if(MPUILibraries)
 	target_link_libraries(${MPUI} ${MPUILibraries})
+	
+	if (GIT_FOUND)
+		add_dependencies(${MPUI} GET_GIT_TAG_AND_HASH)
+	endif()
 endif(MPUILibraries)

--- a/scripts/header/update_header.bat
+++ b/scripts/header/update_header.bat
@@ -1,0 +1,20 @@
+@echo off
+setlocal
+echo Updating Git tag and hash...
+
+:: Check if header file path is provided
+if "%~1"=="" (
+    echo Usage: %~nx0 [HeaderFilePath]
+    exit /b
+)
+
+:: Get the current git tag and hash
+for /f "delims=" %%i in ('git describe --tags --abbrev^=0') do set GIT_TAG=%%i
+for /f "delims=" %%i in ('git rev-parse --short HEAD') do set GIT_HASH=%%i
+
+:: Use powershell to replace the GIT_TAG and GIT_HASH in the header file
+powershell -Command "(gc %~1) -replace '#define GIT_TAG .*', '#define GIT_TAG \""%GIT_TAG%\""' | Out-File -encoding ASCII %~1"
+powershell -Command "(gc %~1) -replace '#define GIT_HASH .*', '#define GIT_HASH \""%GIT_HASH%\""' | Out-File -encoding ASCII %~1"
+
+echo Git tag is %GIT_TAG%
+echo Git hash is %GIT_HASH%

--- a/scripts/header/update_header.sh
+++ b/scripts/header/update_header.sh
@@ -1,0 +1,19 @@
+echo "Updating Git tag and hash..."
+
+# Check if header file path is provided
+if [ -z "$1" ]
+then
+    echo "Usage: $0 [HeaderFilePath]"
+    exit 1
+fi
+
+# Get the current git tag and hash
+GIT_TAG=$(git describe --tags --abbrev=0)
+GIT_HASH=$(git rev-parse --short HEAD)
+
+# Use sed to replace the GIT_TAG and GIT_HASH in the header file
+sed -i -e "s/#define GIT_TAG .*/#define GIT_TAG \"$GIT_TAG\"/g" $1
+sed -i -e "s/#define GIT_HASH .*/#define GIT_HASH \"$GIT_HASH\"/g" $1
+
+echo "Git tag is $GIT_TAG"
+echo "Git hash is $GIT_HASH"

--- a/shared/qcommon/q_version.h.in
+++ b/shared/qcommon/q_version.h.in
@@ -1,5 +1,6 @@
 #cmakedefine SOURCE_DATE "@SOURCE_DATE@"
 #cmakedefine GIT_TAG "@GIT_TAG@"
+#cmakedefine GIT_HASH "@GIT_HASH@"
 #cmakedefine BUILD_PORTABLE
 
 #if !defined(SOURCE_DATE)


### PR DESCRIPTION
updating git tag and hash automatically upon building the binaries. there is an issue with the way the git tag is being generated in cmake.
if you clone the repo, the command that is being used: git describe --tag outputs:

latest

so this ends up being used as GAME_VERSION like so:

#define    JK_VERSION EternalJK: latest

however, if you download the latest release, the JK_VERSION is actually:

#define JK_VERSION EternalJK: latest-22-g596ae40cc

so when cloning, its missing the amount of commits on top of the tagged objects and its missing the commit hash

$ git describe --tag --abbrev=0
latest
$ git rev-parse --short HEAD
c5d27eaea

then combine them so it becomes latest-c5d27eaea