### PR TITLE
Actions Release Tweaks

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -251,7 +251,7 @@ jobs:
       - name: Create binary archives
         run: |
           7z a -r TaystJK-windows-x86.zip ./TaystJK-windows-x86-Release-Non-Portable/* '-x!msvcp*.*' '-x!vcruntime*.*' '-x!concrt*.*'
-          7z a -r TaystJK-windows-x86_64.zip ./TaystJK-windows-x86_64-Release-Non-Portable/* '-x!msvcp*.*' '-x!vcruntime*.*' '-x!concrt*.*'
+          # 7z a -r TaystJK-windows-x86_64.zip ./TaystJK-windows-x86_64-Release-Non-Portable/* '-x!msvcp*.*' '-x!vcruntime*.*' '-x!concrt*.*'
           mv ./TaystJK-linux-x86-Release-Non-Portable/* TaystJK-linux-x86.tar.gz
           mv ./TaystJK-linux-x86_64-Release-Non-Portable/* TaystJK-linux-x86_64.tar.gz
           mv ./TaystJK-macos-x86_64-Release-Non-Portable/* TaystJK-macos-x86_64.tar.gz
@@ -282,7 +282,7 @@ jobs:
       - name: Create binary archives
         run: |
           7z a -r TaystJK-windows-x86.zip         ./TaystJK-windows-x86-Release-Non-Portable/* '-x!msvcp*.*' '-x!vcruntime*.*' '-x!concrt*.*'
-          7z a -r TaystJK-windows-x86_64.zip         ./TaystJK-windows-x86_64-Release-Non-Portable/* '-x!msvcp*.*' '-x!vcruntime*.*' '-x!concrt*.*'
+          # 7z a -r TaystJK-windows-x86_64.zip         ./TaystJK-windows-x86_64-Release-Non-Portable/* '-x!msvcp*.*' '-x!vcruntime*.*' '-x!concrt*.*'
           mv ./TaystJK-linux-x86-Release-Non-Portable/*     ./TaystJK-linux-x86.tar.gz
           mv ./TaystJK-linux-x86_64-Release-Non-Portable/*  ./TaystJK-linux-x86_64.tar.gz
           mv ./TaystJK-macos-x86_64-Release-Non-Portable/*  ./TaystJK-macos-x86_64.tar.gz
@@ -310,9 +310,9 @@ jobs:
             artifact_name: TaystJK-windows-x86.zip
             zip: true
 
-          - artifact_dir: TaystJK-windows-x86_64-Release-Non-Portable/JediAcademy/
-            artifact_name: TaystJK-windows-x86_64.zip
-            zip: true
+          # - artifact_dir: TaystJK-windows-x86_64-Release-Non-Portable/JediAcademy/
+          #   artifact_name: TaystJK-windows-x86_64.zip
+          #   zip: true
 
           - artifact_dir: TaystJK-linux-x86-Release-Non-Portable
             artifact_name: TaystJK-linux-x86.tar.gz

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -91,7 +91,7 @@ jobs:
 
   ubuntu:
     name: Ubuntu ${{ matrix.arch }} ${{ matrix.build_type }} (${{ matrix.portable }})
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-20.04
     strategy:
       fail-fast: false
       matrix:
@@ -119,9 +119,12 @@ jobs:
             sudo dpkg --add-architecture i386
             sudo apt-get -qq update
             sudo apt-get -y install aptitude
-            sudo apt-get -y install gcc-multilib g++-multilib ninja-build
-            sudo apt-get -y install --allow-downgrades libpcre2-8-0:i386 libjpeg-dev:i386 libpng-dev:i386 libcurl4-openssl-dev:i386
+            sudo apt-get -y install --allow-downgrades libpcre2-8-0=10.34-7 gcc-multilib g++-multilib ninja-build libjpeg-dev:i386 libpng-dev:i386 libcurl4-openssl-dev:i386
             sudo aptitude -y install libglib2.0-dev:i386 libsdl2-dev:i386
+            # Use the following for ubuntu 22.04 builds
+            # sudo apt-get -y install gcc-multilib g++-multilib ninja-build
+            # sudo apt-get -y install --allow-downgrades libpcre2-8-0:i386 libjpeg-dev:i386 libpng-dev:i386 libcurl4-openssl-dev:i386
+            # sudo aptitude -y install libglib2.0-dev:i386 libsdl2-dev:i386
           else
             sudo apt-get -qq update
             sudo apt-get install libjpeg-dev libpng-dev zlib1g-dev libsdl2-dev


### PR DESCRIPTION
Build Linux on Ubuntu 20.04 and remove Windows 64-bit builds final release.

Addresses the following:
- Ubuntu builds have issues running on 20.04 when built on 22.04
- Windows 64-bit builds conflict with 32-bit until SDL is separated for 32/64 bit via cmake