### PR TITLE
Defrag racemode demo prerecording fixups

### DIFF
--- a/codemp/qcommon/qcommon.h
+++ b/codemp/qcommon/qcommon.h
@@ -643,6 +643,7 @@ qboolean FS_CompareZipChecksum(const char *zipfile);
 int		FS_GetFileList(  const char *path, const char *extension, char *listbuf, int bufsize );
 int		FS_GetModList(  char *listbuf, int bufsize );
 
+void			FS_AsyncAssureFileClosed(const char* ospath);
 fileHandle_t	FS_FOpenFileWriteAsync( const char *qpath, qboolean safe=qtrue );
 fileHandle_t	FS_FOpenFileWrite( const char *qpath, qboolean safe=qtrue );
 // will properly create any needed paths and deal with seperater character issues

--- a/codemp/server/sv_ccmds.cpp
+++ b/codemp/server/sv_ccmds.cpp
@@ -1779,7 +1779,7 @@ void SV_RecordDemo( client_t *cl, char *demoName ) {
 	if (com_developer->integer) {
 		Com_Printf("recording to %s.\n", name);
 	}
-	cl->demo.demofile = FS_FOpenFileWriteAsync( name );
+	cl->demo.demofile = FS_FOpenFileWriteAsync( name, qtrue );
 	if ( !cl->demo.demofile ) {
 		Com_Printf ("ERROR: couldn't open.\n");
 		return;


### PR DESCRIPTION
# Addresses some crashes TomArrow was experiencing related to async io usage related to racemode file handling:

## 1.

Some targeted debug prints after tracking down the crash. And moved the assert.

## 2. 

Fix for demo being reopened before fully closed, causing a crash subsequently.

## 3.

Fix for race condition that seems to cause crashes, and slightly better handling of failed opening of files in async writing code (I guess this never really happened after all).

It would appear that I misunderstood the problem in my last commit. I assumed that opening the demo had failed because it was still open, but it being still open may have only been a coincidence (although also potentially a source of problems?), and the real cause of the crash may have been our check for file.o, and a some sort of severe IO lag triggered both conditions to happen:
First it caused the old handle to not close in time, and then it caused the thread trying to reopen it to also lag when calling fopen, and as a result file.o would still be NULL, and the condition in FS_FCloseFile would fall through and we would hit our assert and break (or crash miserably in a Release build).

This explains why the writer thread never used to actually exit, and why file.o never ended up being actually NULL when checking in the debugger:
- What actually happened was probably that the assert() tripped after file.o was found to be NULL, but the writer thread didn't care and had all the time in the world to open the file and populate file.o after all, resulting in perplexing debugging outcomes.