### PR TITLE
Performance/memory improvements to demo pre-record code, and cvar to control pre-recording bots.

### DIFF
--- a/codemp/qcommon/msg.cpp
+++ b/codemp/qcommon/msg.cpp
@@ -78,16 +78,7 @@ void MSG_Init( msg_t *buf, byte *data, int length ) {
 	buf->maxsize = length;
 }
 
-void MSG_ToBuffered(msg_t* src, bufferedMsg_t* dst) {
-	dst->allowoverflow = src->allowoverflow;
-	dst->overflowed = src->overflowed;
-	dst->oob = src->oob;
-	dst->maxsize = src->maxsize;
-	dst->cursize = src->cursize;
-	dst->readcount = src->readcount;
-	dst->bit = src->bit;
-	Com_Memcpy(dst->data, src->data, sizeof(dst->data));
-}
+
 
 void MSG_FromBuffered(msg_t* dst, bufferedMsg_t* src) {
 	dst->allowoverflow = src->allowoverflow;
@@ -97,7 +88,7 @@ void MSG_FromBuffered(msg_t* dst, bufferedMsg_t* src) {
 	dst->cursize = src->cursize;
 	dst->readcount = src->readcount;
 	dst->bit = src->bit;
-	Com_Memcpy(dst->data, src->data, sizeof(src->data));
+	Com_Memcpy(dst->data, src->data, src->cursize);
 }
 
 void MSG_InitOOB( msg_t *buf, byte *data, int length ) {

--- a/codemp/server/server.h
+++ b/codemp/server/server.h
@@ -144,7 +144,7 @@ typedef struct {
 #endif
 
 #ifdef DEDICATED
-typedef std::vector<bufferedMessageContainer_t>::iterator demoPreRecordBufferIt;
+typedef std::vector<std::shared_ptr<bufferedMessageContainer_t>>::iterator demoPreRecordBufferIt;
 #endif
 
 typedef struct client_s {

--- a/codemp/server/server.h
+++ b/codemp/server/server.h
@@ -29,6 +29,7 @@ along with this program; if not, see <http://www.gnu.org/licenses/>.
 #include "game/bg_public.h"
 #include "rd-common/tr_public.h"
 #include "server/duel_cull.h"
+#include <memory>
 
 extern int DuelCull(sharedEntity_t *a, sharedEntity_t *b);
 

--- a/codemp/server/server.h
+++ b/codemp/server/server.h
@@ -319,6 +319,7 @@ extern	cvar_t	*sv_maxOOBRateIP;
 extern	cvar_t	*sv_autoWhitelist;
 #ifdef DEDICATED
 extern	cvar_t	*sv_demoPreRecord;
+extern	cvar_t	*sv_demoPreRecordBots;
 extern	cvar_t	*sv_demoPreRecordTime;
 extern	cvar_t	*sv_demoPreRecordKeyframeDistance;
 extern	cvar_t	*sv_demoWriteMeta;

--- a/codemp/server/server.h
+++ b/codemp/server/server.h
@@ -145,7 +145,7 @@ typedef struct {
 #endif
 
 #ifdef DEDICATED
-typedef std::vector<std::shared_ptr<bufferedMessageContainer_t>>::iterator demoPreRecordBufferIt;
+typedef std::vector<std::unique_ptr<bufferedMessageContainer_t>>::iterator demoPreRecordBufferIt;
 #endif
 
 typedef struct client_s {

--- a/codemp/server/sv_ccmds.cpp
+++ b/codemp/server/sv_ccmds.cpp
@@ -31,7 +31,7 @@ along with this program; if not, see <http://www.gnu.org/licenses/>.
 #include <ctime>
 
 #ifdef DEDICATED
-extern std::vector<std::shared_ptr<bufferedMessageContainer_t>> demoPreRecordBuffer[MAX_CLIENTS];
+extern std::vector<std::unique_ptr<bufferedMessageContainer_t>> demoPreRecordBuffer[MAX_CLIENTS];
 extern std::map<std::string, std::string> demoMetaData[MAX_CLIENTS];
 #endif
 

--- a/codemp/server/sv_init.cpp
+++ b/codemp/server/sv_init.cpp
@@ -1031,6 +1031,7 @@ void SV_Init (void) {
 
 #ifdef DEDICATED
 	sv_demoPreRecord = Cvar_Get("sv_demoPreRecord", "0", CVAR_ARCHIVE, "Activate server demo pre-recording so demos can be retroactively recorded for duration sv_demoPreRecordTime (seconds)");
+	sv_demoPreRecordBots = Cvar_Get("sv_demoPreRecordBots", "0", CVAR_ARCHIVE, "Do demo pre-recording for bots as well");
 	sv_demoPreRecordTime = Cvar_Get("sv_demoPreRecordTime", "15", CVAR_ARCHIVE, "How many seconds of past packets should be stored for server demo pre-recording?");
 	sv_demoPreRecordKeyframeDistance = Cvar_Get("sv_demoPreRecordKeyframeDistance", "5", CVAR_ARCHIVE, "A demo can only start with a gamestate and full non-delta snapshot. How often should we save such a gamestate message? The shorter the distance, the more precisely the pre-record duration will be kept, but also the higher the RAM usage and regularity of non-delta frames being sent to the clients.");
 	sv_demoWriteMeta = Cvar_Get("sv_demoWriteMeta", "1", CVAR_ARCHIVE, "Enables writing metadata to demos, which can be set by the server/game. This is invisible to normal clients and can be used for storing information about when the demo was recorded, start of the recording, and so on.");

--- a/codemp/server/sv_main.cpp
+++ b/codemp/server/sv_main.cpp
@@ -77,6 +77,7 @@ cvar_t	*sv_autoWhitelist;
 
 #ifdef DEDICATED
 cvar_t	*sv_demoPreRecord; // Activate demo pre-recording
+cvar_t	*sv_demoPreRecordBots; // Activates demo pre-recording for bots
 cvar_t	*sv_demoPreRecordTime; // How many seconds of past packets should be stored so demos can be retroactively recorded for that duration?
 cvar_t	*sv_demoPreRecordKeyframeDistance; // A demo can only start with a gamestate and full non-delta snapshot. How often should we save such a gamestate message (in seconds)? The shorter the distance, the more precisely the pre-record duration will be kept.
 cvar_t	*sv_demoWriteMeta; // Enables writing metadata to demos, which can be set by the server/game. This is invisible to normal clients and can be used for storing information about when the demo was recorded, start of the recording, and so on.

--- a/codemp/server/sv_snapshot.cpp
+++ b/codemp/server/sv_snapshot.cpp
@@ -839,7 +839,7 @@ void SV_SendMessageToClient( msg_t *msg, client_t *client ) {
 
 		// Now put the current messsage in the buffer.
 		if(client->netchan.remoteAddress.type != NA_BOT || sv_demoPreRecordBots->integer){
-			std::unique_ptr<bufferedMessageContainer_t> bmtPtr = std::make_unique<bufferedMessageContainer_t>(msg);
+			std::unique_ptr<bufferedMessageContainer_t> bmtPtr(new bufferedMessageContainer_t(msg));
 			bufferedMessageContainer_t* bmt = bmtPtr.get();
 			//static bufferedMessageContainer_t bmt; // I make these static so they don't sit on the stack.
 			//Com_Memset(bmt, 0, sizeof(bufferedMessageContainer_t));
@@ -876,7 +876,7 @@ void SV_SendMessageToClient( msg_t *msg, client_t *client ) {
 			client->reliableSent = tmp;
 
 			//MSG_ToBuffered(&keyframeMsg, &bmt->msg);
-			std::unique_ptr<bufferedMessageContainer_t> bmtPtr = std::make_unique<bufferedMessageContainer_t>(&keyframeMsg);
+			std::unique_ptr<bufferedMessageContainer_t> bmtPtr(new bufferedMessageContainer_t(&keyframeMsg));
 			bufferedMessageContainer_t* bmt = bmtPtr.get();
 			bmt->msgNum = client->netchan.outgoingSequence; // Yes the keyframe duplicates the messagenum of a message. This is (part of) why we dump only one keyframe at the start of the demo and discard future keyframes
 			bmt->lastClientCommand = client->lastClientCommand;

--- a/codemp/server/sv_snapshot.cpp
+++ b/codemp/server/sv_snapshot.cpp
@@ -25,7 +25,7 @@ along with this program; if not, see <http://www.gnu.org/licenses/>.
 #include "qcommon/cm_public.h"
 
 #ifdef DEDICATED
-std::vector<bufferedMessageContainer_t> demoPreRecordBuffer[MAX_CLIENTS];
+std::vector<std::shared_ptr<bufferedMessageContainer_t>> demoPreRecordBuffer[MAX_CLIENTS];
 std::map<std::string,std::string> demoMetaData[MAX_CLIENTS];
 #endif
 
@@ -821,7 +821,7 @@ void SV_SendMessageToClient( msg_t *msg, client_t *client ) {
 		demoPreRecordBufferIt lastEvilPackage;
 		qboolean evilPackagesFound = qfalse;
 		for (demoPreRecordBufferIt it = demoPreRecordBuffer[client - svs.clients].begin(); it != demoPreRecordBuffer[client - svs.clients].end(); it++) {
-			if (it->msgNum > client->netchan.outgoingSequence || it->time > sv.time) {
+			if (it->get()->msgNum > client->netchan.outgoingSequence || it->get()->time > sv.time) {
 				lastEvilPackage = it;
 				evilPackagesFound = qtrue;
 			}
@@ -838,14 +838,16 @@ void SV_SendMessageToClient( msg_t *msg, client_t *client ) {
 		}
 
 		// Now put the current messsage in the buffer.
-		static bufferedMessageContainer_t bmt; // I make these static so they don't sit on the stack.
-		Com_Memset(&bmt, 0, sizeof(bufferedMessageContainer_t));
-		MSG_ToBuffered(msg,&bmt.msg);
-		bmt.msgNum = client->netchan.outgoingSequence;
-		bmt.lastClientCommand = client->lastClientCommand;
-		bmt.time = sv.time;
-		bmt.isKeyframe = qfalse; // In theory it might be a gamestate message, but we only call it a keyframe if we ourselves explicitly save a keyframe.
-		demoPreRecordBuffer[client - svs.clients].push_back(bmt);
+		std::shared_ptr<bufferedMessageContainer_t> bmtPtr = std::make_shared<bufferedMessageContainer_t>();
+		bufferedMessageContainer_t* bmt = bmtPtr.get();
+		//static bufferedMessageContainer_t bmt; // I make these static so they don't sit on the stack.
+		Com_Memset(bmt, 0, sizeof(bufferedMessageContainer_t));
+		MSG_ToBuffered(msg,&bmt->msg);
+		bmt->msgNum = client->netchan.outgoingSequence;
+		bmt->lastClientCommand = client->lastClientCommand;
+		bmt->time = sv.time;
+		bmt->isKeyframe = qfalse; // In theory it might be a gamestate message, but we only call it a keyframe if we ourselves explicitly save a keyframe.
+		demoPreRecordBuffer[client - svs.clients].push_back(bmtPtr);
 	}
 
 	// save the message to demo.  this must happen before sending over network as that encodes the backing databuf
@@ -861,9 +863,10 @@ void SV_SendMessageToClient( msg_t *msg, client_t *client ) {
 			// Save a keyframe.
 			static byte keyframeBufData[MAX_MSGLEN]; // I make these static so they don't sit on the stack.
 			static msg_t		keyframeMsg;
-			static bufferedMessageContainer_t bmt;
+			std::shared_ptr<bufferedMessageContainer_t> bmtPtr = std::make_shared<bufferedMessageContainer_t>();
+			bufferedMessageContainer_t* bmt = bmtPtr.get();
 			Com_Memset(&keyframeMsg, 0, sizeof(msg_t));
-			Com_Memset(&bmt, 0, sizeof(bufferedMessageContainer_t));
+			Com_Memset(bmt, 0, sizeof(bufferedMessageContainer_t));
 
 			MSG_Init(&keyframeMsg, keyframeBufData, sizeof(keyframeBufData));
 
@@ -871,12 +874,12 @@ void SV_SendMessageToClient( msg_t *msg, client_t *client ) {
 			SV_CreateClientGameStateMessage(client, &keyframeMsg);
 			client->reliableSent = tmp;
 
-			MSG_ToBuffered(&keyframeMsg, &bmt.msg);
-			bmt.msgNum = client->netchan.outgoingSequence; // Yes the keyframe duplicates the messagenum of a message. This is (part of) why we dump only one keyframe at the start of the demo and discard future keyframes
-			bmt.lastClientCommand = client->lastClientCommand;
-			bmt.time = sv.time;
-			bmt.isKeyframe = qtrue; // This is a keyframe (gamestate that will be followed by non-delta frames)
-			demoPreRecordBuffer[client - svs.clients].push_back(bmt);
+			MSG_ToBuffered(&keyframeMsg, &bmt->msg);
+			bmt->msgNum = client->netchan.outgoingSequence; // Yes the keyframe duplicates the messagenum of a message. This is (part of) why we dump only one keyframe at the start of the demo and discard future keyframes
+			bmt->lastClientCommand = client->lastClientCommand;
+			bmt->time = sv.time;
+			bmt->isKeyframe = qtrue; // This is a keyframe (gamestate that will be followed by non-delta frames)
+			demoPreRecordBuffer[client - svs.clients].push_back(bmtPtr);
 			client->demo.preRecord.minDeltaFrame = 0;
 			client->demo.preRecord.keyframeWaiting = qtrue;
 			client->demo.preRecord.lastKeyframeTime = sv.time;
@@ -889,7 +892,7 @@ void SV_SendMessageToClient( msg_t *msg, client_t *client ) {
 		demoPreRecordBufferIt lastTooOldKeyframe;
 		qboolean lastTooOldKeyframeFound = qfalse;
 		for (demoPreRecordBufferIt it = demoPreRecordBuffer[client - svs.clients].begin(); it != demoPreRecordBuffer[client - svs.clients].end(); it++) {
-			if (it->isKeyframe && (it->time + (1000*sv_demoPreRecordTime->integer)) < sv.time) {
+			if (it->get()->isKeyframe && (it->get()->time + (1000*sv_demoPreRecordTime->integer)) < sv.time) {
 				lastTooOldKeyframe = it;
 				lastTooOldKeyframeFound = qtrue;
 			}


### PR DESCRIPTION
1. Buffered demo messages are no longer fully stored in an std::vector, instead a unique_ptr of them is stored, to reduce the memory footprint of the vector, and to avoid having to allocate and move around big consecutive chunks of memory when adding/removing elements.
2. The data portion of buffered demo messages is now dynamically allocated instead of having a fixed byte array of MAX_MSGLEN (~50K) bytes, thus drastically reducing the overall memory footprint of the pre-record feature. The array is allocated in the constructor of bufferedMsg_t and deleted in the destructor, which is automatically called by unique_ptr when elements are deleted or when the vector is cleared.
3. sv_demoPreRecordBots: New cvar, default 0. If 0, demo messages are not pre-recorded for bots, saving memory. 

Memory use of the entire ded server after one client running through start trigger of a defrag map for 38 hours on the old racepack8 version, with demo pre-recording enabled: 41,468 K (Active private working set), 105,756 K (Commit size).