### PR TITLE
Fix: Pre-recording potentially not working after map changes/servertime resets

### DIFF
--- a/codemp/server/sv_init.cpp
+++ b/codemp/server/sv_init.cpp
@@ -459,7 +459,6 @@ void SV_SpawnServer( char *server, qboolean killBots, ForceReload_e eForceReload
 	const char	*p;
 #ifdef DEDICATED
 	SV_StopAutoRecordDemos();
-	SV_ClearAllDemoPreRecord();
 #endif
 
 	SV_SendMapChange();
@@ -761,7 +760,7 @@ Ghoul2 Insert End
 			SV_SendClientGameState( client );
 		}
 	}
-
+	SV_ClearAllDemoPreRecord();
 	SV_BeginAutoRecordDemos();
 #endif
 }
@@ -1139,6 +1138,11 @@ Ghoul2 Insert Start
 	// free current level
 	SV_ClearServer();
 	CM_ClearMap();//jfm: add a clear here since it's commented out in clearServer.  This prevents crashing cmShaderTable on exit.
+
+#ifdef DEDICATED
+	SV_StopAutoRecordDemos();
+	SV_ClearAllDemoPreRecord();
+#endif
 
 	// free server static data
 	if ( svs.clients ) {

--- a/codemp/server/sv_snapshot.cpp
+++ b/codemp/server/sv_snapshot.cpp
@@ -862,7 +862,7 @@ void SV_SendMessageToClient( msg_t *msg, client_t *client ) {
 	// Check for whether a new keyframe must be written in pre recording, and if so, do it.
 	if (sv_demoPreRecord->integer && (client->netchan.remoteAddress.type != NA_BOT || sv_demoPreRecordBots->integer)) {
 
-		if (client->demo.preRecord.lastKeyframeTime + (1000 * sv_demoPreRecordKeyframeDistance->integer) < sv.time) {
+		if (client->demo.preRecord.lastKeyframeTime + (1000 * sv_demoPreRecordKeyframeDistance->integer) < sv.time || client->demo.preRecord.lastKeyframeTime > sv.time) { // See if it's time for a new keyframe, or if the last keyframe was made before a serverTime restart.
 			// Save a keyframe.
 			static byte keyframeBufData[MAX_MSGLEN]; // I make these static so they don't sit on the stack.
 			static msg_t		keyframeMsg;


### PR DESCRIPTION
Pre-recording could potentially break if a client stays connected throughout a map restart/change, because servertime is reset, but "lastkeyframetime" could potentially stay on the higher value. Since the check to create a new keyframe was expecting sv.time to always be >= the lastkeyframetime, none would be created anymore, thus breaking pre-recording. The result of that is a demo lacking the pre-recorded info.

This should have been avoided by SV_ClearAllDemoPreRecord(); in SV_SpawnServer, however it was called at the beginning of that function, and new messages were sent to the client during the map change and before SV_ClearServer() was called (which resets sv.time), thus causing new keyframes to be generated directly after clearing with the still old servertime and before the actual sv.time reset.

There might be other edge cases where this might happen so for safety a new keyframe is now generated also if client->demo.preRecord.lastKeyframeTime > sv.time. 

And to avoid it happening to begin with in the above circumstance, SV_ClearAllDemoPreRecord(); is called at the end of SV_SpawnServer, long after sv.time is cleared, and removed from the start of SV_SpawnServer to avoid generating a few useless keyframes during the mapchange messages that will be deleted anyway.