### PR TITLE
Fix for endless loop bug in Z_Malloc and flood-protect fix for amtele/amtelemark

### DIFF
--- a/codemp/rd-vanilla/tr_image.cpp
+++ b/codemp/rd-vanilla/tr_image.cpp
@@ -874,7 +874,7 @@ qboolean RE_RegisterImages_LevelLoadEnd(void)
 
 //	int iNumImages = AllocatedImages.size();	// more for curiosity, really.
 
-	qboolean imageDeleted = qtrue;
+	qboolean imageDeleted = qfalse;
 	for (AllocatedImages_t::iterator itImage = AllocatedImages.begin(); itImage != AllocatedImages.end(); /* blank */)
 	{
 		qboolean bEraseOccured = qfalse;

--- a/codemp/server/sv_client.cpp
+++ b/codemp/server/sv_client.cpp
@@ -1578,7 +1578,7 @@ static qboolean SV_ClientCommand( client_t *cl, msg_t *msg ) {
 				else
 					cl->lastReliableTime[3] = svs.time;
 			}
-			else if (!Q_stricmpn(s, "amTele", 6) || !Q_stricmpn(s, "amTeleMark", 10)) {
+			else if (sv_newfloodProtect->integer > 2 && (!Q_stricmpn(s, "amTele", 6) || !Q_stricmpn(s, "amTeleMark", 10))) { // If sv_newFloodProtect is 3 or higher, don't flood protect amtele/amtelemark
 				clientOk = qtrue;
 			}
 			else {


### PR DESCRIPTION
Consists of 2 things.

1. RE_RegisterImages_LevelLoadEnd always returns qtrue atm, due to a variable being wrongly initialized, causing endless loops when called from Z_Alloc. Z_Alloc wants to find ways to free memory... asks RE_RegisterImages_LevelLoadEnd to do so. RE_RegisterImages_LevelLoadEnd reports back that an image was deleted (qtrue) even if no image was deleted. Z_Alloc then thinks ok, let's retry the malloc... endless loop, for hours even, forcing you to quit the process instead of gracefully erroring and disconnecting. You can compare this to the behavior of the original released jka code, it's only supposed to return qtrue if an image was actually deleted, else Z_Alloc can never fall through to the lower down conditions to either delete other stuff like models/sounds or actually gracefully quit. The error was introduced in this commit:
https://github.com/taysta/TaystJK/commit/d405b33c263f92b1984317cb6de8dc49d1bf4ad6

2. Currently amtele/amtelemark is always not ratelimited if sv_newFloodProtect is >1. This may not be desired as in some circumstances people could abuse it to spam teleport sounds/effects. Proposed solution here is to only disable ratelimiting for amtele/amtelemark if sv_newFloodProtect is >2, and otherwise fall back to the old behavior. This allows the old behavior to be restored before the amtele exception was formerly introduced in this commit:
https://github.com/taysta/TaystJK/commit/ef4648a5e069c902c0e8a5fdbd9def57e77c2f8a