### PR TITLE
Fix opengl context leak on vid_restart (causing thread, memory and other resource leaks)

### DIFF
--- a/shared/sdl/sdl_window.cpp
+++ b/shared/sdl/sdl_window.cpp
@@ -858,8 +858,17 @@ void WIN_Shutdown( void )
 
 	IN_Shutdown();
 
+	if ( opengl_context ) {
+		SDL_GL_DeleteContext( opengl_context );
+		opengl_context = NULL;
+	}
+
+	if ( screen ) {
+		SDL_DestroyWindow( screen );
+		screen = NULL;
+	}
+
 	SDL_QuitSubSystem( SDL_INIT_VIDEO );
-	screen = NULL;
 }
 
 void GLimp_EnableLogging( qboolean enable )


### PR DESCRIPTION
SDL opengl context must be destroyed before destroying its window and also before SDL_QuitSubSystem(SDL_INIT_VIDEO) to prevent leaks

(cherry picked from commit 3f4ca6bf50a2448966e4f88b11584d61250b6e43)