### PR TITLE
Vulkan: Upstream changes from quake3e

### DIFF
--- a/codemp/rd-vulkan/vk_instance.cpp
+++ b/codemp/rd-vulkan/vk_instance.cpp
@@ -689,7 +689,8 @@ static qboolean vk_create_device( VkPhysicalDevice physical_device, int device_i
 			vk.shaderStorageImageMultisample = qtrue;
 		}
 
-		if (device_features.fragmentStoresAndAtomics) {
+		if ( device_features.fragmentStoresAndAtomics && device_features.vertexPipelineStoresAndAtomics ) {
+			features.vertexPipelineStoresAndAtomics = VK_TRUE;
 			features.fragmentStoresAndAtomics = VK_TRUE;
 			vk.fragmentStores = qtrue;
 		}

--- a/codemp/rd-vulkan/vk_pipelines.cpp
+++ b/codemp/rd-vulkan/vk_pipelines.cpp
@@ -1889,6 +1889,8 @@ void vk_alloc_persistent_pipelines( void )
 #endif // USE_PMLIGHT
     }
 
+	// flare visibility test dot
+	if ( vk.fragmentStores )
     {
         Com_Memset(&def, 0, sizeof(def));
         def.face_culling = CT_TWO_SIDED;


### PR DESCRIPTION
Vulkan: enable vertexPipelineStoresAndAtomics along with fragmentStoresAndAtomics https://github.com/ec-/Quake3e/commit/0c26ee30f0629427ae677ed12dbbaadc1b2d2f00 (cherry picked from commit 7ca468450d48285769ce7767ed66018ec216d650)