### PR TITLE
macOS fullscreen fix

### DIFF
--- a/shared/sdl/sdl_window.cpp
+++ b/shared/sdl/sdl_window.cpp
@@ -444,7 +444,11 @@ static rserr_t GLimp_SetMode(glconfig_t *glConfig, const windowDesc_t *windowDes
 
 	if( fullscreen )
 	{
+#ifdef MACOS_X
+        flags |= SDL_WINDOW_FULLSCREEN_DESKTOP;
+#else
 		flags |= SDL_WINDOW_FULLSCREEN;
+#endif
 		glConfig->isFullscreen = qtrue;
 	}
 	else


### PR DESCRIPTION
Use SDL_WINDOW_FULLSCREEN_DESKTOP flag on macOS, this enables command+tab, game mode, starting the application under the notch