### PR TITLE
Fix menu force mastery level selection

### DIFF
--- a/codemp/game/bg_misc.c
+++ b/codemp/game/bg_misc.c
@@ -810,10 +810,11 @@ qboolean BG_LegalizedForcePowers(char *powerOut, size_t powerOutSize, int maxRan
 		if (fpDisabled & (1 << FP_LEVITATION))
 			final_Powers[FP_LEVITATION] = 1;
 //[JAPRO - Serverside - Saber - Fix Block/attack Level defaulting to highest - Start]
+// tayst - Reverted these back to 3 as it was causing issues with custom gamers wanting to fight bots with saber only
 		if (fpDisabled & (1 << FP_SABER_OFFENSE))
-			final_Powers[FP_SABER_OFFENSE] = 1;
+			final_Powers[FP_SABER_OFFENSE] = 3;
 		if (fpDisabled & (1 << FP_SABER_DEFENSE))
-			final_Powers[FP_SABER_DEFENSE] = 0; //should this be 0..
+			final_Powers[FP_SABER_DEFENSE] = 3;
 //[JAPRO - Serverside - Saber - Fix Block/attack Level defaulting to highest - End]
 	}
 

--- a/codemp/game/bg_misc.c
+++ b/codemp/game/bg_misc.c
@@ -826,7 +826,7 @@ qboolean BG_LegalizedForcePowers(char *powerOut, size_t powerOutSize, int maxRan
 
 //[JAPRO - Serverside - Saber - Allow server to cap block level - End]
 #ifdef _GAME
-	if (g_maxSaberDefense.integer && (final_Powers[FP_SABER_DEFENSE] > g_maxSaberDefense.integer))//my block is middle[2], forced max is 2,
+	if (g_maxSaberDefense.integer > -1 && (final_Powers[FP_SABER_DEFENSE] > g_maxSaberDefense.integer))//my block is middle[2], forced max is 2,
 		final_Powers[FP_SABER_DEFENSE] = g_maxSaberDefense.integer;
 #endif
 //[JAPRO - Serverside - Saber - Allow server to cap block level - End]

--- a/codemp/game/g_xcvar.h
+++ b/codemp/game/g_xcvar.h
@@ -192,7 +192,7 @@ XCVAR_DEF( g_neutralFlagTimer,			"10000",		NULL,				CVAR_ARCHIVE,									qtrue)
 //JAPRO Saber
 XCVAR_DEF( g_tweakSaber,				"0",			CVU_TweakSaber,		CVAR_ARCHIVE,									qtrue )
 XCVAR_DEF( g_backslashDamageScale,		"1",			NULL,				CVAR_ARCHIVE,									qtrue )
-XCVAR_DEF( g_maxSaberDefense,			"0",			NULL,				CVAR_ARCHIVE|CVAR_LATCH,						qtrue )
+XCVAR_DEF( g_maxSaberDefense,			"-1",			NULL,				CVAR_ARCHIVE|CVAR_LATCH,						qtrue )
 XCVAR_DEF( g_saberTouchDmg,				"0",			NULL,				CVAR_ARCHIVE,									qtrue )
 XCVAR_DEF( g_fixGroundStab,				"0",			NULL,				CVAR_ARCHIVE,									qtrue )
 XCVAR_DEF( g_saberDuelSPDamage,			"1",			NULL,				CVAR_ARCHIVE,									qtrue ) //s ?

--- a/codemp/ui/ui_force.c
+++ b/codemp/ui/ui_force.c
@@ -311,7 +311,7 @@ void UpdateForceUsed()
 	menuDef_t *menu;
 
 	// Currently we don't make a distinction between those that wish to play Jedi of lower than maximum skill.
-	uiForceRank = uiMaxRank;
+	//uiForceRank = uiMaxRank;
 
 	uiForceUsed = 0;
 	if (uiMaxRank <= MAX_FORCE_RANK)
@@ -1000,6 +1000,8 @@ qboolean UI_ForceMaxRank_HandleKey(int flags, float *special, int key, int num, 
 
 	// The update force used will remove overallocated powers automatically.
 	UpdateForceUsed();
+
+	uiForceRank = num;
 
 	gTouchedForce = qtrue;
 

--- a/docs/japro_docs.md
+++ b/docs/japro_docs.md
@@ -12,7 +12,7 @@
 #### Saber
 	g_tweakSaber			0	//Configured with /tweakSaber command.
 	g_backslashDamageScale	1	
-	g_maxSaberDefense		0	
+	g_maxSaberDefense		-1	// -1 disables, 0/1/2/3 enables and clamps level
 	g_saberTouchDmg			0	//Configure saber touch damage for MP dmgs. Can be >1 for more touch damage.
 	g_fixGroundStab			0	//1=Groundstabs damage players on ground. 2=Groundstabs damage players on ground but with reduced damage.
 	g_saberDuelSPDamage		1	//Toggle use of SP style damage in saber duels.


### PR DESCRIPTION
- Also reverts old jaPRO change where force powers disabled results in saber attack and defense to be levels 1/0 instead of 3/3.