### PR TITLE
Libjpeg turbo

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -56,6 +56,9 @@ jobs:
       - name: Add msbuild to PATH
         uses: microsoft/setup-msbuild@v2
 
+      - name: Setup NASM
+        uses: ilammy/setup-nasm@v1
+
       - name: Create Build Environment
         run: cmake -E make_directory ${{ github.workspace }}/build
 
@@ -65,9 +68,9 @@ jobs:
         run: |
           OPTIONS="-DCMAKE_BUILD_TYPE=${{ matrix.build_type }} -DCMAKE_INSTALL_PREFIX=bin"
           if [ "${{ matrix.portable }}" == "Portable" ]; then
-            OPTIONS+=" -DBuildPortableVersion=ON"
+            OPTIONS+=" -DUseTurboJPEG=ON -DBuildPortableVersion=ON"
           else
-            OPTIONS+=" -DBuildPortableVersion=OFF"
+            OPTIONS+=" -DUseTurboJPEG=ON -DBuildPortableVersion=OFF"
           fi
           cmake $GITHUB_WORKSPACE -A ${{ matrix.platform }} $OPTIONS
 
@@ -113,6 +116,9 @@ jobs:
           fetch-depth: 0
           fetch-tags: true
 
+      - name: Setup NASM
+        uses: ilammy/setup-nasm@v1
+
       - name: Create Build Environment
         run: |
           if [ ${{ matrix.arch }} == "x86" ]; then
@@ -137,9 +143,9 @@ jobs:
         run: |
           OPTIONS="-DCMAKE_BUILD_TYPE=${{ matrix.build_type }} -DCMAKE_INSTALL_PREFIX=${{ github.workspace }}/install"
           if [ "${{ matrix.portable }}" == "Portable" ]; then
-            OPTIONS+=" -DUseInternalLibs=ON -DBuildPortableVersion=ON"
+            OPTIONS+=" -DUseInternalLibs=ON -DUseTurboJPEG=ON -DBuildPortableVersion=ON"
           else
-            OPTIONS+=" -DUseInternalLibs=OFF -DBuildPortableVersion=OFF"
+            OPTIONS+=" -DUseInternalLibs=OFF -DUseTurboJPEG=ON -DBuildPortableVersion=OFF"
           fi
           if [ ${{ matrix.arch }} == "x86" ]; then
             OPTIONS+=" -DCMAKE_TOOLCHAIN_FILE=cmake/Toolchains/linux-i686.cmake"
@@ -194,6 +200,9 @@ jobs:
           fetch-depth: 0
           fetch-tags: true
 
+      - name: Setup NASM
+        uses: ilammy/setup-nasm@v1
+
       - name: Create Build Environment
         run: |
           brew install sdl2
@@ -205,9 +214,9 @@ jobs:
         run: |
           OPTIONS="-DCMAKE_BUILD_TYPE=${{ matrix.build_type }} -DCMAKE_INSTALL_PREFIX=${{ github.workspace }}/install"
           if [ "${{ matrix.portable }}" == "Portable" ]; then
-            OPTIONS+=" -DUseInternalLibs=ON -DBuildPortableVersion=ON"
+            OPTIONS+=" -DUseInternalLibs=ON -DUseTurboJPEG=ON -DBuildPortableVersion=ON"
           else
-            OPTIONS+=" -DUseInternalLibs=OFF -DBuildPortableVersion=OFF"
+            OPTIONS+=" -DUseInternalLibs=OFF -DUseTurboJPEG=ON -DBuildPortableVersion=OFF"
           fi
           cmake $GITHUB_WORKSPACE $OPTIONS
 
@@ -261,6 +270,9 @@ jobs:
           fetch-depth: 0
           fetch-tags: true
 
+      - name: Setup NASM
+        uses: ilammy/setup-nasm@v1
+
       - name: Create Build Environment
         run: |
           brew install sdl2
@@ -272,9 +284,9 @@ jobs:
         run: |
           OPTIONS="-DCMAKE_OSX_ARCHITECTURES=arm64 -DCMAKE_SYSTEM_PROCESSOR=arm64 -DCMAKE_BUILD_TYPE=${{ matrix.build_type }} -DCMAKE_INSTALL_PREFIX=${{ github.workspace }}/install"
           if [ "${{ matrix.portable }}" == "Portable" ]; then
-            OPTIONS+=" -DUseInternalLibs=ON -DBuildPortableVersion=ON"
+            OPTIONS+=" -DUseInternalLibs=ON -DUseTurboJPEG=ON -DBuildPortableVersion=ON"
           else
-            OPTIONS+=" -DUseInternalLibs=OFF -DBuildPortableVersion=OFF"
+            OPTIONS+=" -DUseInternalLibs=OFF -DUseTurboJPEG=ON -DBuildPortableVersion=OFF"
           fi
           cmake $GITHUB_WORKSPACE $OPTIONS
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -75,6 +75,9 @@ jobs:
             throw "Visual Studio installation not found"
           }
 
+      - name: Setup NASM
+        uses: ilammy/setup-nasm@72793074d3c8cdda771dba85f6deafe00623038b
+
       - name: Create Build Environment
         run: cmake -E make_directory ${{ github.workspace }}/build
 
@@ -84,9 +87,9 @@ jobs:
         run: |
           OPTIONS="-DCMAKE_BUILD_TYPE=${{ matrix.build_type }} -DCMAKE_INSTALL_PREFIX=bin"
           if [ "${{ matrix.portable }}" == "Portable" ]; then
-            OPTIONS+=" -DBuildPortableVersion=ON"
+            OPTIONS+=" -DBuildPortableVersion=ON -DUseTurboJPEG=ON "
           else
-            OPTIONS+=" -DBuildPortableVersion=OFF"
+            OPTIONS+=" -DBuildPortableVersion=OFF -DUseTurboJPEG=ON "
           fi
           cmake $GITHUB_WORKSPACE -A ${{ matrix.platform }} $OPTIONS
 
@@ -139,6 +142,9 @@ jobs:
           fetch-depth: 0
           fetch-tags: true
 
+      - name: Setup NASM
+        uses: ilammy/setup-nasm@72793074d3c8cdda771dba85f6deafe00623038b
+
       - name: Create Build Environment
         run: |
           if [ ${{ matrix.arch }} == "x86" ]; then
@@ -157,9 +163,9 @@ jobs:
         run: |
           OPTIONS="-DCMAKE_BUILD_TYPE=${{ matrix.build_type }} -DCMAKE_INSTALL_PREFIX=${{ github.workspace }}/install"
           if [ "${{ matrix.portable }}" == "Portable" ]; then
-            OPTIONS+=" -DBuildPortableVersion=ON"
+            OPTIONS+=" -DBuildPortableVersion=ON -DUseTurboJPEG=ON"
           else
-            OPTIONS+=" -DBuildPortableVersion=OFF"
+            OPTIONS+=" -DBuildPortableVersion=OFF -DUseTurboJPEG=ON"
           fi
           if [ ${{ matrix.arch }} == "x86" ]; then
             OPTIONS+=" -DCMAKE_TOOLCHAIN_FILE=cmake/Toolchains/linux-i686.cmake"
@@ -214,6 +220,9 @@ jobs:
           fetch-depth: 0
           fetch-tags: true
 
+      - name: Setup NASM
+        uses: ilammy/setup-nasm@72793074d3c8cdda771dba85f6deafe00623038b
+
       - name: Create Build Environment
         run: |
           brew install sdl2
@@ -225,9 +234,9 @@ jobs:
         run: |
           OPTIONS="-DCMAKE_BUILD_TYPE=${{ matrix.build_type }} -DCMAKE_INSTALL_PREFIX=${{ github.workspace }}/install"
           if [ "${{ matrix.portable }}" == "Portable" ]; then
-            OPTIONS+=" -DBuildPortableVersion=ON"
+            OPTIONS+=" -DBuildPortableVersion=ON -DUseTurboJPEG=ON"
           else
-            OPTIONS+=" -DBuildPortableVersion=OFF"
+            OPTIONS+=" -DBuildPortableVersion=OFF -DUseTurboJPEG=ON"
           fi
           cmake $GITHUB_WORKSPACE $OPTIONS
 
@@ -284,6 +293,9 @@ jobs:
           fetch-depth: 0
           fetch-tags: true
 
+      - name: Setup NASM
+        uses: ilammy/setup-nasm@72793074d3c8cdda771dba85f6deafe00623038b
+
       - name: Create Build Environment
         run: |
           brew install sdl2
@@ -295,9 +307,9 @@ jobs:
         run: |
           OPTIONS="-DCMAKE_OSX_ARCHITECTURES=${{ matrix.arch }} -DCMAKE_SYSTEM_PROCESSOR=${{ matrix.arch }} -DCMAKE_BUILD_TYPE=${{ matrix.build_type }} -DCMAKE_INSTALL_PREFIX=${{ github.workspace }}/install"
           if [ "${{ matrix.portable }}" == "Portable" ]; then
-            OPTIONS+=" -DBuildPortableVersion=ON"
+            OPTIONS+=" -DBuildPortableVersion=ON -DUseTurboJPEG=ON"
           else
-            OPTIONS+=" -DBuildPortableVersion=OFF"
+            OPTIONS+=" -DBuildPortableVersion=OFF -DUseTurboJPEG=ON"
           fi
           cmake $GITHUB_WORKSPACE $OPTIONS
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -17,6 +17,7 @@
 #============================================================================
 
 cmake_minimum_required(VERSION 3.10)
+include(ExternalProject)
 set(CMAKE_OSX_DEPLOYMENT_TARGET "10.9" CACHE STRING "Minimum OS X deployment version")
 
 set(InOpenJK ON)
@@ -80,6 +81,11 @@ option(UseInternalZlib   "If set, use bundled zlib."    ${UseInternalZlibDefault
 option(UseInternalPNG    "If set, use bundled libpng."  ${UseInternalPNGDefault})
 option(UseInternalJPEG   "If set, use bundled libjpeg." ${UseInternalJPEGDefault})
 option(UseInternalSDL2   "If set, use bundled SDL2."    ${UseInternalSDL2Default})
+
+if(UseInternalJPEG)
+	set(UseTurboJPEGDefault   	 OFF)
+	option(UseTurboJPEG "If set, use libjpeg-turbo." ${UseTurboJPEGDefault})
+endif()
 
 # This option won't appear on non-Apple platforms.
 if(APPLE)
@@ -415,9 +421,35 @@ set(SharedCommonSafeFiles
 #
 #=============================================================================
 if(UseInternalJPEG)
-  add_subdirectory(lib/jpeg-9c)
+	if(UseTurboJPEG)
+		find_program(CMAKE_ASM_NASM_COMPILER NAMES nasm)
+		if(CMAKE_ASM_NASM_COMPILER)
+			message(STATUS "Found NASM assembler: ${CMAKE_ASM_NASM_COMPILER}")
+			set(WITH_SIMD 1)
+		else()
+			message(WARNING "NASM assembler not found - libjpeg-turbo will be built without SIMD optimizations")
+			set(WITH_SIMD 0)
+		endif()
+
+		# Configure the ExternalProject for libjpeg-turbo
+		ExternalProject_Add(libjpeg-turbo
+				GIT_REPOSITORY https://github.com/libjpeg-turbo/libjpeg-turbo.git
+				GIT_TAG 3.0.0
+				BUILD_COMMAND ${CMAKE_COMMAND} --build . --target jpeg-static --config ${CMAKE_BUILD_TYPE}
+				INSTALL_COMMAND ""
+				CMAKE_ARGS
+				-DCMAKE_ASM_NASM_COMPILER=${CMAKE_ASM_NASM_COMPILER}
+				-DWITH_SIMD=${WITH_SIMD}
+				-DENABLE_SHARED=0
+				-DWITH_ARITH_DEC=0
+				-DWITH_ARITH_ENC=0
+				-DWITH_TURBOJPEG=0
+				-DCMAKE_BUILD_TYPE=${CMAKE_BUILD_TYPE})
+	else()
+		add_subdirectory(lib/jpeg-9c)
+	endif()
 else()
-  find_package(JPEG REQUIRED)
+	find_package(JPEG REQUIRED)
 endif()
 
 if(UseInternalZlib)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -85,6 +85,11 @@ option(UseInternalPNG    "If set, use bundled libpng."  ${UseInternalPNGDefault}
 option(UseInternalJPEG   "If set, use bundled libjpeg." ${UseInternalJPEGDefault})
 option(UseInternalSDL2   "If set, use bundled SDL2."    ${UseInternalSDL2Default})
 
+if(UseInternalJPEG)
+	set(UseTurboJPEGDefault   	 OFF)
+	option(UseTurboJPEG "If set, use libjpeg-turbo." ${UseTurboJPEGDefault})
+endif()
+
 # This option won't appear on non-Apple platforms.
 if(APPLE)
   option(MakeApplicationBundles "Whether to build .app application bundles for engines built" ON)
@@ -433,7 +438,35 @@ set(SharedCommonSafeFiles
 # FIXME: the renderers should declare their own dependencies
 if(BuildMPRdVanilla OR BuildMPRdVulkan OR BuildMPRend2)
 	if(UseInternalJPEG)
-		add_subdirectory(lib/jpeg-9c)
+		if(UseTurboJPEG)
+			include(ExternalProject)
+			find_program(CMAKE_ASM_NASM_COMPILER NAMES nasm)
+			if(CMAKE_ASM_NASM_COMPILER)
+				message(STATUS "Found NASM assembler: ${CMAKE_ASM_NASM_COMPILER}")
+				set(WITH_SIMD 1)
+			else()
+				message(WARNING "NASM assembler not found - libjpeg-turbo will be built without SIMD optimizations")
+				set(WITH_SIMD 0)
+			endif()
+
+			ExternalProject_Add(libjpeg-turbo
+					GIT_REPOSITORY https://github.com/libjpeg-turbo/libjpeg-turbo.git
+					GIT_TAG 3.1.4.1
+					BUILD_COMMAND ${CMAKE_COMMAND} --build . --target jpeg-static --config ${CMAKE_BUILD_TYPE}
+					INSTALL_COMMAND ""
+					CMAKE_ARGS
+					-DCMAKE_ASM_NASM_COMPILER=${CMAKE_ASM_NASM_COMPILER}
+					-DWITH_SIMD=${WITH_SIMD}
+					-DENABLE_SHARED=0
+					-DWITH_ARITH_DEC=0
+					-DWITH_ARITH_ENC=0
+					-DWITH_TURBOJPEG=0
+					-DWITH_TOOLS=0
+					-DWITH_TESTS=0
+					-DCMAKE_BUILD_TYPE=${CMAKE_BUILD_TYPE})
+		else()
+			add_subdirectory(lib/jpeg-9c)
+		endif()
 	else()
 		find_package(JPEG REQUIRED)
 	endif()

--- a/codemp/CMakeLists.txt
+++ b/codemp/CMakeLists.txt
@@ -48,6 +48,17 @@ if(BuildMPUI)
 	add_subdirectory("${MPDir}/ui")
 endif(BuildMPUI)
 
+if(UseInternalJPEG AND UseTurboJPEG)
+	ExternalProject_Get_Property(libjpeg-turbo BINARY_DIR SOURCE_DIR)
+	set(JPEG_INCLUDE_DIR "${SOURCE_DIR}")
+	set(JPEG_CONFIG_DIR "${BINARY_DIR}")
+	if(WIN32)
+		set(JPEG_LIBRARIES "${BINARY_DIR}/${CMAKE_BUILD_TYPE}/jpeg-static.lib")
+	else()
+		set(JPEG_LIBRARIES "${BINARY_DIR}/libjpeg.a")
+	endif()
+endif()
+
 #	 Add Vanilla JKA Renderer Project
 if(BuildMPRdVanilla)
 	add_subdirectory("${MPDir}/rd-vanilla")
@@ -688,6 +699,21 @@ if(BuildMPEngine)
 	if (GIT_FOUND)
 		add_dependencies(${MPEngine} GET_GIT_TAG_AND_HASH)
 	endif()
+
+	if(UseInternalJPEG AND UseTurboJPEG)
+		if(BuildMPRdVanilla)
+			add_dependencies(${MPVanillaRenderer} libjpeg-turbo)
+		endif()
+
+		if(BuildMPRdVulkan)
+			add_dependencies(${MPVulkanRenderer} libjpeg-turbo)
+		endif()
+
+		if(BuildMPRend2)
+			add_dependencies(${MPRend2} libjpeg-turbo)
+		endif()
+	endif()
+
 endif(BuildMPEngine)
 
 #        Dedicated Server (Engine) (jampded.exe)

--- a/codemp/CMakeLists.txt
+++ b/codemp/CMakeLists.txt
@@ -48,6 +48,17 @@ if(BuildMPUI)
 	add_subdirectory("${MPDir}/ui")
 endif(BuildMPUI)
 
+if(UseInternalJPEG AND UseTurboJPEG)
+	ExternalProject_Get_Property(libjpeg-turbo BINARY_DIR SOURCE_DIR)
+	set(JPEG_INCLUDE_DIR "${SOURCE_DIR}/src")
+	set(JPEG_CONFIG_DIR "${BINARY_DIR}")
+	if(WIN32)
+		set(JPEG_LIBRARIES "${BINARY_DIR}/${CMAKE_BUILD_TYPE}/jpeg-static.lib")
+	else()
+		set(JPEG_LIBRARIES "${BINARY_DIR}/libjpeg.a")
+	endif()
+endif()
+
 #	 Add Vanilla JKA Renderer Project
 if(BuildMPRdVanilla)
 	add_subdirectory("${MPDir}/rd-vanilla")
@@ -688,6 +699,21 @@ if(BuildMPEngine)
 	if (GIT_FOUND)
 		add_dependencies(${MPEngine} GET_GIT_TAG_AND_HASH)
 	endif()
+
+	if(UseInternalJPEG AND UseTurboJPEG)
+		if(BuildMPRdVanilla)
+			add_dependencies(${MPVanillaRenderer} libjpeg-turbo)
+		endif()
+
+		if(BuildMPRdVulkan)
+			add_dependencies(${MPVulkanRenderer} libjpeg-turbo)
+		endif()
+
+		if(BuildMPRend2)
+			add_dependencies(${MPRend2} libjpeg-turbo)
+		endif()
+	endif()
+
 endif(BuildMPEngine)
 
 #        Dedicated Server (Engine) (jampded.exe)

--- a/codemp/rd-rend2/CMakeLists.txt
+++ b/codemp/rd-rend2/CMakeLists.txt
@@ -121,6 +121,9 @@ set(MPRend2Files ${MPRend2Files} ${MPRend2CommonSafeFiles})
 
 # Transparently use either bundled or system libjpeg.
 list(APPEND MPRend2IncludeDirectories ${JPEG_INCLUDE_DIR})
+if(UseInternalJPEG AND UseTurboJPEG)
+	list(APPEND MPRend2IncludeDirectories ${JPEG_CONFIG_DIR})
+endif()
 list(APPEND MPRend2Libraries          ${JPEG_LIBRARIES})
 
 # Transparently use either bundled or system libpng.  Order is important --

--- a/codemp/rd-rend2/CMakeLists.txt
+++ b/codemp/rd-rend2/CMakeLists.txt
@@ -119,6 +119,9 @@ set(MPRend2Files ${MPRend2Files} ${MPRend2CommonSafeFiles})
 
 # Transparently use either bundled or system libjpeg.
 list(APPEND MPRend2IncludeDirectories ${JPEG_INCLUDE_DIR})
+if(UseInternalJPEG AND UseTurboJPEG)
+	list(APPEND MPRend2IncludeDirectories ${JPEG_CONFIG_DIR})
+endif()
 list(APPEND MPRend2Libraries          ${JPEG_LIBRARIES})
 
 # Transparently use either bundled or system libpng.  Order is important --

--- a/codemp/rd-vanilla/CMakeLists.txt
+++ b/codemp/rd-vanilla/CMakeLists.txt
@@ -112,6 +112,9 @@ set(MPVanillaRendererFiles ${MPVanillaRendererFiles} ${MPVanillaRendererCommonSa
 
 # Transparently use either bundled or system libjpeg.
 list(APPEND MPVanillaRendererIncludeDirectories ${JPEG_INCLUDE_DIR})
+if(UseInternalJPEG AND UseTurboJPEG)
+	list(APPEND MPVanillaRendererIncludeDirectories ${JPEG_CONFIG_DIR})
+endif()
 list(APPEND MPVanillaRendererLibraries          ${JPEG_LIBRARIES})
 
 # Transparently use either bundled or system libpng.  Order is important --

--- a/codemp/rd-vulkan/CMakeLists.txt
+++ b/codemp/rd-vulkan/CMakeLists.txt
@@ -142,6 +142,9 @@ set(MPVulkanRendererFiles ${MPVulkanRendererFiles} ${MPVulkanRendererCommonSafeF
 
 # Transparently use either bundled or system libjpeg.
 list(APPEND MPVulkanRendererIncludeDirectories ${JPEG_INCLUDE_DIR})
+if(UseInternalJPEG AND UseTurboJPEG)
+	list(APPEND MPVulkanRendererIncludeDirectories ${JPEG_CONFIG_DIR})
+endif()
 list(APPEND MPVulkanRendererLibraries          ${JPEG_LIBRARIES})
 
 # Transparently use either bundled or system libpng.  Order is important --

--- a/codemp/rd-vulkan/CMakeLists.txt
+++ b/codemp/rd-vulkan/CMakeLists.txt
@@ -147,6 +147,9 @@ set(MPVulkanRendererFiles ${MPVulkanRendererFiles} ${MPVulkanRendererCommonSafeF
 
 # Transparently use either bundled or system libjpeg.
 list(APPEND MPVulkanRendererIncludeDirectories ${JPEG_INCLUDE_DIR})
+if(UseInternalJPEG AND UseTurboJPEG)
+	list(APPEND MPVulkanRendererIncludeDirectories ${JPEG_CONFIG_DIR})
+endif()
 list(APPEND MPVulkanRendererLibraries          ${JPEG_LIBRARIES})
 
 # Transparently use either bundled or system libpng.  Order is important --


### PR DESCRIPTION
Build with cmake flag `-DUseTurboJPEG` (default off) to use libjpeg-turbo, needs [nasm](https://www.nasm.us/) installed and added to path for SIMD instructions, is detected by cmake and can build without if not installed. This implementation using ExternalProject, so it will fetch and compile libjpeg turbo upon build, also set github actions releases to install nasm and build with jpegturbo. 

Should reduce map load times.

based on: https://github.com/aufau/jk2mv/tree/libjpeg-turbo