### PR TITLE
Fixed the ability to bind to the NumPad in the UI

### DIFF
--- a/codemp/ui/ui_shared.c
+++ b/codemp/ui/ui_shared.c
@@ -1477,6 +1477,7 @@ void Menus_CloseAll()
 	int i;
 
 	g_waitingForKey = qfalse;
+	DC->setCVar( "com_waitingForKey", "0" );
 
 	for (i = 0; i < menuCount; i++)
 	{
@@ -4385,6 +4386,7 @@ void Menu_HandleKey(menuDef_t *menu, int key, qboolean down) {
 				Item_RunScript(&it, menu->onESC);
 			}
 			g_waitingForKey = qfalse;
+			DC->setCVar( "com_waitingForKey", "0" );
 			break;
 		case A_TAB:
 		case A_KP_2:
@@ -4444,6 +4446,7 @@ void Menu_HandleKey(menuDef_t *menu, int key, qboolean down) {
 					it.parent = menu;
 					Item_RunScript(&it, menu->onESC);
 					g_waitingForKey = qfalse;
+					DC->setCVar( "com_waitingForKey", "0" );
 					break;
 				}
 				else {
@@ -5280,6 +5283,7 @@ qboolean Item_Bind_HandleKey(itemDef_t *item, int key, qboolean down) {
 		if (down) {
 			g_waitingForKey = qtrue;
 			g_bindItem = item;
+			DC->setCVar( "com_waitingForKey", "1" );
 		}
 		return qtrue;
 	}
@@ -5287,6 +5291,7 @@ qboolean Item_Bind_HandleKey(itemDef_t *item, int key, qboolean down) {
 		if ( down ) {
 			g_waitingForKey = qtrue;
 			g_bindItem = item;
+			DC->setCVar( "com_waitingForKey", "1" );
 		}
 		return qtrue;
 	}
@@ -5302,6 +5307,7 @@ qboolean Item_Bind_HandleKey(itemDef_t *item, int key, qboolean down) {
 		switch ( key ) {
 			case A_ESCAPE:
 				g_waitingForKey = qfalse;
+				DC->setCVar( "com_waitingForKey", "0" );
 				return qtrue;
 
 			case A_BACKSPACE:
@@ -5319,6 +5325,7 @@ qboolean Item_Bind_HandleKey(itemDef_t *item, int key, qboolean down) {
 				}
 				Controls_SetConfig();
 				g_waitingForKey = qfalse;
+				DC->setCVar( "com_waitingForKey", "0" );
 				g_bindItem = NULL;
 				return qtrue;
 
@@ -5369,6 +5376,7 @@ qboolean Item_Bind_HandleKey(itemDef_t *item, int key, qboolean down) {
 
 	Controls_SetConfig();
 	g_waitingForKey = qfalse;
+	DC->setCVar( "com_waitingForKey", "0" );
 
 	return qtrue;
 }

--- a/shared/sdl/sdl_input.cpp
+++ b/shared/sdl/sdl_input.cpp
@@ -198,7 +198,9 @@ static bool IN_NumLockEnabled( void )
 
 static void IN_TranslateNumpad( SDL_Keysym *keysym, fakeAscii_t *key )
 {
-	if ( IN_NumLockEnabled() && Key_GetCatcher() )
+	com_waitingForKey = Cvar_Get( "com_waitingForKey", "0", CVAR_ROM );
+
+	if ( IN_NumLockEnabled() && Key_GetCatcher() && !com_waitingForKey->integer )
 	{
 		switch ( keysym->sym )
 		{

--- a/shared/sys/sys_main.cpp
+++ b/shared/sys/sys_main.cpp
@@ -42,6 +42,8 @@ cvar_t *com_maxfpsMinimized;
 cvar_t *com_maxfpsUnfocused;
 cvar_t *com_unpackLibraries;
 
+cvar_t *com_waitingForKey; // Waiting to bind a new key in the UI
+
 /*
 =================
 Sys_SetBinaryPath
@@ -175,6 +177,8 @@ void Sys_Init( void ) {
 	com_maxfpsMinimized = Cvar_Get( "com_maxfpsMinimized", "50", CVAR_ARCHIVE_ND );
 
 	com_unpackLibraries = Cvar_Get( "com_unpackLibraries", "0", CVAR_INIT|CVAR_PROTECTED );
+
+	com_waitingForKey = Cvar_Get( "com_waitingForKey", "0", CVAR_ROM );
 }
 
 static void NORETURN Sys_Exit( int ex ) {

--- a/shared/sys/sys_public.h
+++ b/shared/sys/sys_public.h
@@ -89,6 +89,8 @@ extern cvar_t *com_maxfps;
 extern cvar_t *com_maxfpsMinimized;
 extern cvar_t *com_maxfpsUnfocused;
 
+extern cvar_t *com_waitingForKey; // Waiting to bind a new key in the UI
+
 sysEvent_t	Sys_GetEvent( void );
 
 void	Sys_Init (void);


### PR DESCRIPTION
## Description

In **TaystJK**, the ability to bind NumPad keys in the UI **with NumLock ON** is currently broken.  
It binds to numbers \[0-9\], which then **cannot** be used from the NumPad.

This PR fixes it, and also gives the ability to bind NumPad keys independently from the number row
(above QWERTY / AZERTY / QWERTZ / …), which is purposefully *different* behavior from OpenJK and vanilla `jamp.exe`.

### Known limitation
It isn't perfect, because, when NumLock is OFF, it's impossible to differentiate the arrow keys on the numpad
(2, 4, 6, and 8) from the "regular" arrow keys (respectively `Down`, `Left`, `Right` and `Up`).

## TaystJK's current behavior
|  Num  | Bind with NumLock ON | Usable with NumLock ON | Usable with NumLock OFF | \|  | Bind with NumLock OFF | Usable with NumLock ON | Usable with NumLock OFF |
| :---: | :------------------: | :--------------------- | :---------------------- | --- | :-------------------- | :--------------------- | :---------------------- |
|   0   | `0`                  | ❌ No¹                 | ❌ No¹                 | \|  | `KP_INS`              | ✅ Yes                 | ✅ Yes                 |
|   1   | `1`                  | ❌ No¹                 | ❌ No¹                 | \|  | `KP_END`              | ✅ Yes                 | ✅ Yes                 |
|   2   | `2`                  | ❌ No¹                 | ❌ No¹                 | \|  | ⚠️ `DOWN`²            | ❌ No³                 | ⚠️ Yes²                |
|   3   | `3`                  | ❌ No¹                 | ❌ No¹                 | \|  | `KP_PGDN`             | ✅ Yes                 | ✅ Yes                 |
|   4   | `4`                  | ❌ No¹                 | ❌ No¹                 | \|  | ⚠️ `LEFT`²            | ❌ No³                 | ⚠️ Yes²                |
|   5   | `5`                  | ❌ No¹                 | ❌ No¹                 | \|  | `KP_5`                | ✅ Yes                 | ✅ Yes                 |
|   6   | `6`                  | ❌ No¹                 | ❌ No¹                 | \|  | ⚠️ `RIGHT`²           | ❌ No³                 | ⚠️ Yes²                |
|   7   | `7`                  | ❌ No¹                 | ❌ No¹                 | \|  | `KP_HOME`             | ✅ Yes                 | ✅ Yes                 |
|   8   | `8`                  | ❌ No¹                 | ❌ No¹                 | \|  | ⚠️ `UP`²              | ❌ No³                 | ⚠️ Yes²                |
|   9   | `9`                  | ❌ No¹                 | ❌ No¹                 | \|  | `KP_PGUP`             | ✅ Yes                 | ✅ Yes                 |

**Notes:**
1. ❌ You *have* to use the number row (above QWERTY / AZERTY / QWERTZ / …) – even though you used the NumPad when binding in the UI
2. ⚠️ Conflicts with the "regular" arrow keys
3. ❌ You *have* to use the "regular" arrow keys – even though you used the NumPad when binding in the UI  
   → or to disable NumLock

## This PR's behavior
|  Num  | Bind with NumLock ON | Usable with NumLock ON | Usable with NumLock OFF | \|  | Bind with NumLock OFF | Usable with NumLock ON | Usable with NumLock OFF |
| :---: | :------------------- | :--------------------- | :---------------------- | --- | :-------------------- | :--------------------- | :---------------------- |
|   0   | `KP_INS`             | ✅ **Yes**             | ✅ **Yes**             | \|  | `KP_INS`              | ✅ Yes                 | ✅ Yes                 |
|   1   | `KP_END`             | ✅ **Yes**             | ✅ **Yes**             | \|  | `KP_END`              | ✅ Yes                 | ✅ Yes                 |
|   2   | `KP_DOWN`            | ✅ **Yes**             | ❌ No                  | \|  | ⚠️ `DOWN`¹            | ❌ No²                 | ⚠️ Yes¹                |
|   3   | `KP_PGDN`            | ✅ **Yes**             | ✅ **Yes**             | \|  | `KP_PGDN`             | ✅ Yes                 | ✅ Yes                 |
|   4   | `KP_LEFT`            | ✅ **Yes**             | ❌ No                  | \|  | ⚠️ `LEFT`¹            | ❌ No²                 | ⚠️ Yes¹                |
|   5   | `KP_5`               | ✅ **Yes**             | ✅ **Yes**             | \|  | `KP_5`                | ✅ Yes                 | ✅ Yes                 |
|   6   | `KP_RIGHT`           | ✅ **Yes**             | ❌ No             | \|  | ⚠️ `RIGHT`¹           | ❌ No²                 | ⚠️ Yes¹                |
|   7   | `KP_HOME`            | ✅ **Yes**             | ✅ **Yes**             | \|  | `KP_HOME`             | ✅ Yes                 | ✅ Yes                 |
|   8   | `KP_UP`              | ✅ **Yes**             | ❌ No                  | \|  | ⚠️ `UP`¹              | ❌ No²                 | ⚠️ Yes¹                |
|   9   | `KP_PGUP`            | ✅ **Yes**             | ✅ **Yes**             | \|  | `KP_PGUP`             | ✅ Yes                 | ✅ Yes                 |

**Notes:**
1. ⚠️ Conflicts with the "regular" arrow keys
2. ❌ You *have* to use the "regular" arrow keys – even though you used the NumPad when binding in the UI  
   → or to disable NumLock

## OpenJK / jamp.exe behavior
|  Num | Bind with NumLock ON | Usable with NumLock ON | Usable with NumLock OFF | \|  | Bind with NumLock OFF | Usable with NumLock ON | Usable with NumLock OFF |
| :---: | :------------------: | :--------------------- | :---------------------- | --- | :-------------------- | :--------------------- | :---------------------- |
|   0   | `0`                  | ⚠️ Yes¹                | ❌ No²                 | \|  | `KP_INS`              | ❌ **No**              | ✅ Yes                 |
|   1   | `1`                  | ⚠️ Yes¹                | ❌ No²                 | \|  | `KP_END`              | ❌ **No**              | ✅ Yes                 |
|   2   | `2`                  | ⚠️ Yes¹                | ❌ No²                 | \|  | ⚠️ `DOWN`³            | ❌ No⁴                 | ⚠️ Yes³                |
|   3   | `3`                  | ⚠️ Yes¹                | ❌ No²                 | \|  | `KP_PGDN`             | ❌ **No**              | ✅ Yes                 |
|   4   | `4`                  | ⚠️ Yes¹                | ❌ No²                 | \|  | ⚠️ `LEFT`³            | ❌ No⁴                 | ⚠️ Yes³                |
|   5   | `5`                  | ⚠️ Yes¹                | ❌ No²                 | \|  | `KP_5`                | ❌ **No**              | ✅ Yes                 |
|   6   | `6`                  | ⚠️ Yes¹                | ❌ No²                 | \|  | ⚠️ `RIGHT`³           | ❌ No⁴                 | ⚠️ Yes³                |
|   7   | `7`                  | ⚠️ Yes¹                | ❌ No²                 | \|  | `KP_HOME`             | ❌ **No**              | ✅ Yes                 |
|   8   | `8`                  | ⚠️ Yes¹                | ❌ No²                 | \|  | ⚠️ `UP`³              | ❌ No⁴                 | ⚠️ Yes³                |
|   9   | `9`                  | ⚠️ Yes¹                | ❌ No²                 | \|  | `KP_PGUP`             | ❌ **No**              | ✅ Yes                 |

**Notes:**
1. ⚠️ Conflicts with the number row (above QWERTY / AZERTY / QWERTZ / …)
2. ❌ You *have* to use the number row (above QWERTY / AZERTY / QWERTZ / …) – even though you used the NumPad when binding in the UI  
   → or to enable NumLock
3. ⚠️ Conflicts with the "regular" arrow keys
4. ❌ You *have* to use the "regular" arrow keys – even though you used the NumPad when binding in the UI  
   → or to disable NumLock
