### PR TITLE
Feature flags

### DIFF
--- a/codemp/cgame/cg_local.h
+++ b/codemp/cgame/cg_local.h
@@ -2245,6 +2245,7 @@ typedef struct cgs_s {
 	int			cinfo;
 	int			jcinfo;
 	int			jcinfo2;
+	int         taystJKinfo;
 	qboolean	pluginSet;
 	qboolean	legacyProtocol; //for compatibility with 1.00 servers
 	int			restricts;//make this a short?

--- a/codemp/cgame/cg_players.c
+++ b/codemp/cgame/cg_players.c
@@ -6025,12 +6025,12 @@ static QINLINE int ClampSaberColor(int color) {
 	if (color == SABER_BLACK)
 		return (PLUGIN_NO_BLACKSABERS || cg_noRGBSabers.integer) ? SABER_ORANGE : SABER_BLACK;
 
-	if (color > SABER_PURPLE && (cg_noRGBSabers.integer || cgs.serverMod < SVMOD_JAPLUS)) {
+	if (color > SABER_PURPLE && (cg_noRGBSabers.integer || ((cgs.serverMod < SVMOD_JAPLUS) && !(cgs.taystJKinfo & TAYSTJK_INFO_RGBSABERS)))) {
 		if (disco.integer)
 			color = Q_irand(0, 5);
-		else if (color >= SABER_RGB && cg_noRGBSabers.integer > 1 && cgs.serverMod >= SVMOD_JAPLUS)
+		else if (color >= SABER_RGB && cg_noRGBSabers.integer > 1 && ((cgs.serverMod >= SVMOD_JAPLUS) || (cgs.taystJKinfo & TAYSTJK_INFO_RGBSABERS)))
 			color = SABER_RGB;
-		else if (color > SABER_PURPLE && (cg_noRGBSabers.integer || cgs.serverMod < SVMOD_JAPLUS))
+		else if (color > SABER_PURPLE && (cg_noRGBSabers.integer || ((cgs.serverMod < SVMOD_JAPLUS) && !(cgs.taystJKinfo & TAYSTJK_INFO_RGBSABERS))))
 			color -= SABER_RGB; //roll over to a normal base color?
 	}
 

--- a/codemp/cgame/cg_players.c
+++ b/codemp/cgame/cg_players.c
@@ -6017,7 +6017,7 @@ static QINLINE void ParseRGBSaber( char *str, vec3_t c ) {
 	}
 }
 
-#define PLUGIN_NO_BLACKSABERS ((cgs.serverMod < SVMOD_JAPLUS || !(cp_pluginDisable.integer & JAPRO_PLUGIN_BLACKSABERSDISABLE)))
+#define PLUGIN_NO_BLACKSABERS (((cgs.serverMod < SVMOD_JAPLUS) && !(cgs.taystJKinfo & TAYSTJK_INFO_BLACKSABERS)) || (cp_pluginDisable.integer & JAPRO_PLUGIN_BLACKSABERSDISABLE))
 static QINLINE int ClampSaberColor(int color) {
 	if (color >= NUM_SABER_COLORS)
 		color = color % NUM_SABER_COLORS; //cap it to highest 'valid' color?

--- a/codemp/cgame/cg_servercmds.c
+++ b/codemp/cgame/cg_servercmds.c
@@ -243,6 +243,7 @@ void CG_ParseServerinfo( void ) {
 	cgs.pluginSet = qfalse;
 	cgs.legacyProtocol = qfalse;
 	cgs.restricts = 0;
+	cgs.taystJKinfo =  atoi(Info_ValueForKey(info, "taystJKinfo")); // taystjk feature flags
 
 	gamename = Info_ValueForKey(info, "gamename");
 	if (gamename) {

--- a/codemp/game/bg_public.h
+++ b/codemp/game/bg_public.h
@@ -546,6 +546,9 @@ extern int bgForcePowerCost[NUM_FORCE_POWERS][NUM_FORCE_POWER_LEVELS];
 #define JAPRO_PLUGIN_CENTERMUZZLE			(1<<27)
 #define JAPRO_PLUGIN_CONSOLECP				(1<<28)
 
+//taystjk feature flags
+#define TAYSTJK_INFO_RGBSABERS              (1<<0)
+
 #define _SPPHYSICS 1
 #define _COOP 1
 typedef enum //movementstyle enum

--- a/codemp/game/bg_public.h
+++ b/codemp/game/bg_public.h
@@ -548,6 +548,7 @@ extern int bgForcePowerCost[NUM_FORCE_POWERS][NUM_FORCE_POWER_LEVELS];
 
 //taystjk feature flags
 #define TAYSTJK_INFO_RGBSABERS              (1<<0)
+#define TAYSTJK_INFO_BLACKSABERS            (1<<1)
 
 #define _SPPHYSICS 1
 #define _COOP 1


### PR DESCRIPTION
This PR adds a feature flag system for server-client capability negotiation. This approach allows for granular feature offerings, as opposed to the current all-or-nothing mod detection according to gamename approach.