### PR TITLE
Fix crash when NPCs use RGB sabers

### DIFF
--- a/codemp/cgame/cg_players.c
+++ b/codemp/cgame/cg_players.c
@@ -12238,7 +12238,11 @@ skipTrail:
 
 	if (cent->currentState.eFlags & EF_INVULNERABLE)
 	{
-		if ((cg_stylePlayer.integer & JAPRO_STYLE_COLOREDSPAWNBUBBLE) && cgs.gametype >= GT_TEAM && cgs.gametype != GT_CTY) {
+		if (
+			(cg_stylePlayer.integer & JAPRO_STYLE_COLOREDSPAWNBUBBLE)
+			&& cgs.gametype >= GT_TEAM && cgs.gametype != GT_CTY
+			&& cent->currentState.number < MAX_CLIENTS
+		) {
 			if (cgs.clientinfo[cent->currentState.number].team == TEAM_RED)
 				CG_DrawPlayerSphere(cent, cent->lerpOrigin, 1.2f, cgs.media.ysaliredShader);
 			else

--- a/codemp/cgame/cg_players.c
+++ b/codemp/cgame/cg_players.c
@@ -6042,7 +6042,12 @@ static QINLINE int ClampSaberColor(int color) {
 
 static void CG_RGBForSaberColor( saber_colors_t color, vec3_t rgb, int cnum, int bnum ) //rgb
 {
-	clientInfo_t *ci = &cgs.clientinfo[cnum];
+	clientInfo_t *ci = NULL;
+	if (cnum >= MAX_CLIENTS) {
+		ci = cg_entities[cnum].npcClient;
+	} else {
+		ci = &cgs.clientinfo[cnum];
+	}
 #if NEW_SABER_PARMS
 	if (ci->saber[bnum].useCustomRGBColor)
 		color = SABER_RGB;


### PR DESCRIPTION
Fixes an out-of-bounds access that would (or could) crash TaystJK when NPCs were given an RGB saber.  
See: https://github.com/NexiloDev/Lugormod-v3/issues/108

Thanks to Daggo and Alereon who found the cause of the crash.