### PR TITLE
Fix "cg_drawRewards 2" sometimes playing regular sounds instead of Q3

### DIFF
--- a/codemp/cgame/cg_playerstate.c
+++ b/codemp/cgame/cg_playerstate.c
@@ -449,11 +449,19 @@ void CG_CheckLocalSounds( playerState_t *ps, playerState_t *ops ) {
 			if (ps->persistant[PERS_PLAYEREVENTS] != ops->persistant[PERS_PLAYEREVENTS]) {
 				if ((ps->persistant[PERS_PLAYEREVENTS] & PLAYEREVENT_DENIEDREWARD) !=
 					(ops->persistant[PERS_PLAYEREVENTS] & PLAYEREVENT_DENIEDREWARD)) {
-					trap->S_StartLocalSound( cgs.media.deniedSound, CHAN_ANNOUNCER );
+					if (cg_drawRewards.integer == 1) {
+						trap->S_StartLocalSound( cgs.media.deniedSound, CHAN_ANNOUNCER );
+					} else if (cg_drawRewards.integer == 2) {
+						trap->S_StartLocalSound( cgs.media.deniedSoundQ3, CHAN_ANNOUNCER );
+					}
 				}
 				else if ((ps->persistant[PERS_PLAYEREVENTS] & PLAYEREVENT_GAUNTLETREWARD) !=
 					(ops->persistant[PERS_PLAYEREVENTS] & PLAYEREVENT_GAUNTLETREWARD)) {
-					trap->S_StartLocalSound( cgs.media.humiliationSound, CHAN_ANNOUNCER );
+					if (cg_drawRewards.integer == 1) {
+						trap->S_StartLocalSound( cgs.media.humiliationSound, CHAN_ANNOUNCER );
+					} else if (cg_drawRewards.integer == 2) {
+						trap->S_StartLocalSound( cgs.media.humiliationSoundQ3, CHAN_ANNOUNCER );
+					}
 				}
 				reward = qtrue;
 			}


### PR DESCRIPTION
I found out about `cg_drawRewards 2` a few days ago.  
I love it 😄

As a reminder, this option turns TaystJK awards into Quake-3-style awards.  
For instance, when a player gets 2 kills in less than 3 seconds:
- With `cg_drawRewards 0`, nothing special happens,
- With `cg_drawRewards 1`, they get a "medal" and assorted sound (*"Ace award"* in Mon Mothma’s voice),
- With `cg_drawRewards 2`, they get a "medal" resembling more closely the one from Quake 3, and they hear *"Excellent"* in a deep voice.

---

This PR fixes a minor issue related to `cg_drawRewards 2` sounds:

**Situation 1:** "Player A" frags "Player B" using the stun baton.  
- "Player A" hears the expected *"Humiliation"* line, in a deep, Quake-3-announcer-style voice.
- However, before the fix, "Player B" would hear *"Demolitionist award"* in Mon Mothma’s voice instead.

**Situation 2:** "Player A" snags a power up right in front of "Player B" (Force Boon, Force Enlightenment, …).
- "Player B" would hear *"Denied"* in Mon Mothma’s voice, instead of the expected Q3-style voice.
- ("Player A" doesn’t hear anything, but that’s by design).