### PR TITLE
Add support for widescreen levelshots

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ Key: [-] removed, [+] added, [\*] modified
 
 ## Tayst's Fork
 
+* [+] Added support for widescreen levelshots. 16:9 levelshots are loaded from `levelshots_16_9/<map_name>` (if available).
 * [*] Add attack/altattack inputs to `cg_movementKeys`
 * [+] Add console/chat field support for [shift+]ctrl+backspace/del/left/right shortcuts
 * [+] New team overlay `cg_drawTeamOverlay 3`, use `cg_drawTeamOverlay 4` to ignore local client  

--- a/codemp/cgame/cg_info.c
+++ b/codemp/cgame/cg_info.c
@@ -133,7 +133,8 @@ void CG_DrawInformation( void ) {
 	const char	*sysInfo;
 	float		y;
 	int			value, valueNOFP;
-	qhandle_t	levelshot;
+	qhandle_t	levelshot = 0;
+	qboolean	isWidescreenLevelshot = qfalse; // 16:9
 	char		buf[1024];
 	int			iPropHeight = 18;	// I know, this is total crap, but as a post release asian-hack....  -Ste
 
@@ -141,15 +142,34 @@ void CG_DrawInformation( void ) {
 	sysInfo = CG_ConfigString( CS_SYSTEMINFO );
 
 	s = Info_ValueForKey( info, "mapname" );
-	levelshot = trap->R_RegisterShaderNoMip( va( "levelshots/%s", s ) );
+
 	trap->R_SetColor( NULL );
 
-	if (levelshot && cgs.widthRatioCoef < 1.0f) {
+	if (cgs.widthRatioCoef <= 0.76f) {
+		levelshot = trap->R_RegisterShaderNoMip(va( "levelshots_16_9/%s", s ));
+		if (levelshot) {
+			isWidescreenLevelshot = qtrue;
+		}
+	}
+
+	if (!levelshot) {
+		levelshot = trap->R_RegisterShaderNoMip( va( "levelshots/%s", s ) );
+	}
+
+	if (levelshot && isWidescreenLevelshot) {
+		CG_DrawPic(
+			0,
+			0 - (SCREEN_HEIGHT * (0.75f / cgs.widthRatioCoef) - SCREEN_HEIGHT) / 2,
+			SCREEN_WIDTH,
+			SCREEN_HEIGHT * (0.75f / cgs.widthRatioCoef),
+			levelshot
+		);
+	} else if (levelshot && cgs.widthRatioCoef < 1.0f) {
 		CG_DrawPic(0, 0 - (SCREEN_HEIGHT*(1 / cgs.widthRatioCoef) - SCREEN_HEIGHT) / 2, SCREEN_WIDTH, SCREEN_HEIGHT*(1 / cgs.widthRatioCoef), levelshot);
 	}
 	else {
 
-		if (!levelshot && cgs.widthRatioCoef >= 0.74f && cgs.widthRatioCoef <= 0.76f)
+		if (!levelshot && cgs.widthRatioCoef <= 0.76f)
 			levelshot = trap->R_RegisterShaderNoMip("menu/art/unknownmap_mp_16_9");
 
 		if ( !levelshot )

--- a/codemp/rd-rend2/tr_init.cpp
+++ b/codemp/rd-rend2/tr_init.cpp
@@ -303,7 +303,7 @@ static void R_Splash()
 	GL_Cull(CT_TWO_SIDED);
 
 	image_t *pImage = R_FindImageFile( "menu/splash", IMGTYPE_COLORALPHA, IMGFLAG_NONE);
-    if (cl_ratioFix->integer && ratio >= 0.74f && ratio <= 0.76f)
+    if (cl_ratioFix->integer && ratio <= 0.76f)
         pImage = R_FindImageFile("menu/splash_16_9", IMGTYPE_COLORALPHA, IMGFLAG_NONE);
 	if (pImage )
 		GL_Bind( pImage );

--- a/codemp/rd-vanilla/tr_init.cpp
+++ b/codemp/rd-vanilla/tr_init.cpp
@@ -292,7 +292,7 @@ void R_Splash()
 	image_t *pImage = NULL;
 	float ratio = (float)(SCREEN_WIDTH * glConfig.vidHeight) / (float)(SCREEN_HEIGHT * glConfig.vidWidth);
 
-	if (cl_ratioFix->integer && ratio >= 0.74f && ratio <= 0.76f)
+	if (cl_ratioFix->integer && ratio <= 0.76f)
 		pImage = R_FindImageFile("menu/splash_16_9", qfalse, qfalse, qfalse, GL_CLAMP);
 
 	if (!pImage)

--- a/codemp/rd-vulkan/vk_init.cpp
+++ b/codemp/rd-vulkan/vk_init.cpp
@@ -179,7 +179,7 @@ static void vk_render_splash( void )
 
 	ratio = ( (float)( SCREEN_WIDTH * glConfig.vidHeight ) / (float)( SCREEN_HEIGHT * glConfig.vidWidth ) );
 
-	if ( cl_ratioFix->integer && ratio >= 0.74f && ratio <= 0.76f ){
+	if ( cl_ratioFix->integer && ratio <= 0.76f ){
 		splashImage = R_FindImageFile("menu/splash_16_9", IMGFLAG_CLAMPTOEDGE);
 
 		if ( !splashImage ){

--- a/codemp/ui/ui_main.c
+++ b/codemp/ui/ui_main.c
@@ -2127,13 +2127,21 @@ static void UI_DrawMapPreview(rectDef_t *rect, float scale, vec4_t color, qboole
 	}
 
 	if (uiInfo.mapList[map].levelShot == -1) {
-		uiInfo.mapList[map].levelShot = trap->R_RegisterShaderNoMip(uiInfo.mapList[map].imageName);
+		if (uiInfo.uiDC.widthRatioCoef <= 0.76f) {
+			uiInfo.mapList[map].levelShot = trap->R_RegisterShaderNoMip(
+				va("levelshots_16_9/%s", uiInfo.mapList[map].mapLoadName)
+			);
+		}
+
+		if (uiInfo.mapList[map].levelShot <= 0) {
+			uiInfo.mapList[map].levelShot = trap->R_RegisterShaderNoMip(uiInfo.mapList[map].imageName);
+		}
 	}
 
 	if (uiInfo.mapList[map].levelShot > 0) {
 		levelShot = uiInfo.mapList[map].levelShot;
 	}
-	else if ((uiInfo.uiDC.widthRatioCoef >= 0.74f) && (uiInfo.uiDC.widthRatioCoef <= 0.76f)) {
+	else if (uiInfo.uiDC.widthRatioCoef <= 0.76f) {
 		levelShot = trap->R_RegisterShaderNoMip("menu/art/unknownmap_mp_16_9");
 	}
 
@@ -2411,8 +2419,7 @@ static void UI_DrawNetMapPreview(rectDef_t *rect, float scale, vec4_t color) {
 	qhandle_t previewImage = 0;
 	if (uiInfo.serverStatus.currentServerPreview > 0) {
 		previewImage = uiInfo.serverStatus.currentServerPreview;
-	}
-	else if ((uiInfo.uiDC.widthRatioCoef >= 0.74f) && (uiInfo.uiDC.widthRatioCoef <= 0.76f)) {
+	} else if (uiInfo.uiDC.widthRatioCoef <= 0.76f) {
 		previewImage = trap->R_RegisterShaderNoMip("menu/art/unknownmap_mp_16_9");
 	}
 
@@ -2461,7 +2468,17 @@ static void UI_DrawTierMap(rectDef_t *rect, int index) {
 	}
 
 	if (uiInfo.tierList[i].mapHandles[index] == -1) {
-		uiInfo.tierList[i].mapHandles[index] = trap->R_RegisterShaderNoMip(va("levelshots/%s", uiInfo.tierList[i].maps[index]));
+		if (uiInfo.uiDC.widthRatioCoef <= 0.76f) {
+			uiInfo.tierList[i].mapHandles[index] = trap->R_RegisterShaderNoMip(
+				va("levelshots_16_9/%s", uiInfo.tierList[i].maps[index])
+			);
+		}
+
+		if (uiInfo.tierList[i].mapHandles[index] <= 0) {
+			uiInfo.tierList[i].mapHandles[index] = trap->R_RegisterShaderNoMip(
+				va("levelshots/%s", uiInfo.tierList[i].maps[index])
+			);
+		}
 	}
 
 	UI_DrawHandlePic( rect->x, rect->y, rect->w, rect->h, uiInfo.tierList[i].mapHandles[index]);
@@ -12175,7 +12192,7 @@ void UI_DrawConnectScreen( qboolean overlay ) {
 
 	char sStringEdTemp[256];
 
-	menuDef_t *menu = (uiInfo.uiDC.widthRatioCoef >= 0.74f && uiInfo.uiDC.widthRatioCoef <= 0.76f) ? Menus_FindByName("Connect_16_9") : Menus_FindByName("Connect");
+	menuDef_t *menu = (uiInfo.uiDC.widthRatioCoef <= 0.76f) ? Menus_FindByName("Connect_16_9") : Menus_FindByName("Connect");
 
 	if (!menu)
 		menu = Menus_FindByName("Connect");


### PR DESCRIPTION
## Context
TaystJK performs aspect ratio correction on levelshots while loading maps. Levelshots are expected to represent a **4:3** image.  
While this works well for default levelshots (in terms of aspect ratio), it unfortunately stretches my [widescreen levelshots](https://jkhub.org/files/file/4179-widescreen-levelshots/) *vertically*, when loading maps.

Also note that the main menu UI does not benefit from aspect correction, which means that 4:3 levelshots still get stretched *horizontally* in map thumbnails (e.g. **"Solo game"** or **"Create a game"**).

## Proposal
- When the screen aspect ratio is 16:9, try to load levelshots from the `levelshots_16_9/%s` path (and then `levelshots/%s`, if not found).
  - 16:9 levelshots will now have their correct aspect ratio both in thumbnails, and when loading maps.
  - 4:3 levelshots will still get their aspect ratio corrected while loading maps (the current behavior doesn’t change).

- Additionally, also use widescreen levelshots – and splashscreens – instead of 4:3 for screens with aspect ratios *wider* than 16:9 (i.e. ultrawide).
  - 16:9 levelshots will keep their correct aspect ratio when fullscreen (they will get cropped, not stretched).
  - `menu/art/unknownmap_mp_16_9` and splashscreens won’t get cropped, and will still get stretched horizontally (less than with the 4:3 versions, though).
  - 16:9 levelshots will still get stretched horizontally in the menu UI (again, less than the 4:3 versions)

## Testing material
Here’s a modified version of my levelshots pack, where the containing folder is `levelshots_16_9`, instead of `levelshots`.
- [widescreen_levelshots_taystjk.zip](https://github.com/user-attachments/files/23688311/widescreen_levelshots_taystjk.zip)

Just rename the file from `.zip` to `.pk3`.

## Note
If this feature/enhancement is too specific, it’s perfectly OK not to merge it.