### PR TITLE
[MP] Fix memory leak when loading sub BSPs (#1294)

### DIFF
--- a/codemp/qcommon/cm_load.cpp
+++ b/codemp/qcommon/cm_load.cpp
@@ -757,7 +757,12 @@ static void CM_LoadMap_Actual( const char *name, qboolean clientload, int *check
 	//	for the renderer to chew on... (but not if this gets ported to a big-endian machine, because some of the
 	//	map data will have been Little-Long'd, but some hasn't).
 	//
-	if (Sys_LowPhysicalMemory()
+	// For sub BSPs, always free immediately since caching only applies to main maps
+	if ( newBuff && newBuff != gpvCachedMapDiskImage )
+	{
+		Z_Free(newBuff);
+	}
+	else if (Sys_LowPhysicalMemory()
 		|| com_dedicated->integer
 //		|| we're on a big-endian machine
 		)


### PR DESCRIPTION
(cherry picked from commit e76263d85b6ba47e761ba6d0e07e5aaba967f4a6)