### PR TITLE
Rend2 Fix

### DIFF
--- a/codemp/rd-vulkan/vk_pipelines.cpp
+++ b/codemp/rd-vulkan/vk_pipelines.cpp
@@ -1699,7 +1699,7 @@ static void vk_create_blur_pipeline( char *name, int program_index, uint32_t ind
     VkSpecializationInfo frag_spec_info;
     VkRenderPass renderpass;
     VkPipeline *pipeline;
-    uint32_t i;
+    //uint32_t i;
 
     switch( program_index ){
         case 1:

--- a/shared/rd-rend2/tr_backend.cpp
+++ b/shared/rd-rend2/tr_backend.cpp
@@ -2502,8 +2502,7 @@ static void RB_UpdateEntityLightConstants(
 	}
 
 	VectorCopy(lightDir, entityBlock.modelLightDir);
-	entityBlock.lightOrigin[3] = 0.0f;
-	entityBlock.lightRadius = lightRadius;
+	entityBlock.lightOrigin[3] = lightRadius;
 }
 
 static void RB_UpdateEntityMatrixConstants(
@@ -2513,7 +2512,6 @@ static void RB_UpdateEntityMatrixConstants(
 	orientationr_t ori;
 	R_RotateForEntity(refEntity, &backEnd.viewParms, &ori);
 	Matrix16Copy(ori.modelMatrix, entityBlock.modelMatrix);
-	VectorCopy(ori.viewOrigin, entityBlock.localViewOrigin);
 }
 
 static void RB_UpdateEntityModelConstants(

--- a/shared/rd-rend2/tr_local.h
+++ b/shared/rd-rend2/tr_local.h
@@ -798,13 +798,11 @@ struct EntityBlock
 	matrix_t modelMatrix;
 	vec4_t lightOrigin;
 	vec3_t ambientLight;
-	float lightRadius;
+	float entityTime;
 	vec3_t directedLight;
 	float fxVolumetricBase;
 	vec3_t modelLightDir;
 	float vertexLerp;
-	vec3_t localViewOrigin;
-	float entityTime;
 	bool operator == (const EntityBlock &other) const
 	{
 		return (


### PR DESCRIPTION
Adds a commit that was missing from rend2, and comments out an referenced variable in vk in order to suppress a compilation warning.