### PR TITLE
Fix warnings identified by clang

### DIFF
--- a/codemp/botlib/l_precomp.cpp
+++ b/codemp/botlib/l_precomp.cpp
@@ -735,7 +735,7 @@ int PC_ExpandBuiltinDefine(source_t *source, token_t *deftoken, define_t *define
 	{
 		case BUILTIN_LINE:
 		{
-			sprintf(token->string, "%d", deftoken->line);
+			Com_sprintf(token->string, sizeof(token->string), "%d", deftoken->line);
 #ifdef NUMBERVALUE
 			token->intvalue = deftoken->line;
 			token->floatvalue = deftoken->line;
@@ -2510,7 +2510,7 @@ int PC_Directive_eval(source_t *source)
 	token.whitespace_p = source->scriptstack->script_p;
 	token.endwhitespace_p = source->scriptstack->script_p;
 	token.linescrossed = 0;
-	sprintf(token.string, "%ld", labs(value));
+	Com_sprintf(token.string, sizeof(token.string), "%ld", labs(value));
 	token.type = TT_NUMBER;
 	token.subtype = TT_INTEGER|TT_LONG|TT_DECIMAL;
 	PC_UnreadSourceToken(source, &token);
@@ -2533,7 +2533,7 @@ int PC_Directive_evalfloat(source_t *source)
 	token.whitespace_p = source->scriptstack->script_p;
 	token.endwhitespace_p = source->scriptstack->script_p;
 	token.linescrossed = 0;
-	sprintf(token.string, "%1.2f", fabs(value));
+	Com_sprintf(token.string, sizeof(token.string), "%1.2f", fabs(value));
 	token.type = TT_NUMBER;
 	token.subtype = TT_FLOAT|TT_LONG|TT_DECIMAL;
 	PC_UnreadSourceToken(source, &token);
@@ -2615,7 +2615,7 @@ int PC_DollarDirective_evalint(source_t *source)
 	token.whitespace_p = source->scriptstack->script_p;
 	token.endwhitespace_p = source->scriptstack->script_p;
 	token.linescrossed = 0;
-	sprintf(token.string, "%ld", labs(value));
+	Com_sprintf(token.string, sizeof(token.string), "%ld", labs(value));
 	token.type = TT_NUMBER;
 	token.subtype = TT_INTEGER|TT_LONG|TT_DECIMAL;
 
@@ -2646,7 +2646,7 @@ int PC_DollarDirective_evalfloat(source_t *source)
 	token.whitespace_p = source->scriptstack->script_p;
 	token.endwhitespace_p = source->scriptstack->script_p;
 	token.linescrossed = 0;
-	sprintf(token.string, "%1.2f", fabs(value));
+	Com_sprintf(token.string, sizeof(token.string), "%1.2f", fabs(value));
 	token.type = TT_NUMBER;
 	token.subtype = TT_FLOAT|TT_LONG|TT_DECIMAL;
 

--- a/codemp/client/snd_mem.cpp
+++ b/codemp/client/snd_mem.cpp
@@ -331,7 +331,7 @@ void R_CheckMP3s( const char *psDir )
 		for (i=2;i<numdirs;i++)
 		{
 			char	sDirName[MAX_QPATH];
-			sprintf(sDirName, "%s\\%s", psDir, dirFiles[i]);
+			Com_sprintf(sDirName, sizeof(sDirName), "%s\\%s", psDir, dirFiles[i]);
 			R_CheckMP3s(sDirName);
 		}
 	}
@@ -340,7 +340,7 @@ void R_CheckMP3s( const char *psDir )
 	for(i=0; i<numSysFiles; i++)
 	{
 		char	sFilename[MAX_QPATH];
-		sprintf(sFilename,"%s\\%s", psDir, sysFiles[i]);
+		Com_sprintf(sFilename, sizeof(sFilename),"%s\\%s", psDir, sysFiles[i]);
 
 		Com_Printf("%sFound file: %s",!i?"\n":"",sFilename);
 

--- a/codemp/rd-common/tr_font.cpp
+++ b/codemp/rd-common/tr_font.cpp
@@ -861,7 +861,7 @@ qboolean Language_UsesSpaces(void)
 //
 static const char *FontDatPath( const char *_fontName ) {
 	static char fontName[MAX_QPATH];
-	sprintf( fontName,"fonts/%s.fontdat",COM_SkipPath(const_cast<char*>(_fontName)) );	// COM_SkipPath should take a const char *, but it's just possible people use it as a char * I guess, so I have to hack around like this <groan>
+	Com_sprintf( fontName,sizeof(fontName), "fonts/%s.fontdat",COM_SkipPath(const_cast<char*>(_fontName)) );	// COM_SkipPath should take a const char *, but it's just possible people use it as a char * I guess, so I have to hack around like this <groan>
 	return fontName;
 }
 CFontInfo::CFontInfo(const char *_fontName)
@@ -962,11 +962,11 @@ CFontInfo::CFontInfo(const char *_fontName)
 			{
 				char sTemp[MAX_QPATH];
 
-				sprintf(sTemp,"fonts/%s.tga", g_SBCSOverrideLanguages[i].m_psName );
+				Com_sprintf(sTemp, sizeof(sTemp), "fonts/%s.tga", g_SBCSOverrideLanguages[i].m_psName );
 				ri.FS_FOpenFileRead( sTemp, &f, qfalse );
 				if (f) ri.FS_FCloseFile( f );
 
-				sprintf(sTemp,"fonts/%s.fontdat", g_SBCSOverrideLanguages[i].m_psName );
+				Com_sprintf(sTemp, sizeof(sTemp), "fonts/%s.fontdat", g_SBCSOverrideLanguages[i].m_psName );
 				ri.FS_FOpenFileRead( sTemp, &f, qfalse );
 				if (f) ri.FS_FCloseFile( f );
 			}

--- a/codemp/rd-common/tr_image_tga.cpp
+++ b/codemp/rd-common/tr_image_tga.cpp
@@ -67,7 +67,7 @@ void LoadTGA ( const char *name, byte **pic, int *width, int *height)
 
 	*pic = NULL;
 
-#define TGA_FORMAT_ERROR(blah) {sprintf(sErrorString,blah); bFormatErrors = true; goto TGADone;}
+#define TGA_FORMAT_ERROR(blah) {Q_strncpyz(sErrorString, blah, sizeof(sErrorString)); bFormatErrors = true; goto TGADone;}
 //#define TGA_FORMAT_ERROR(blah) Com_Error( ERR_DROP, blah );
 
 	//

--- a/codemp/rd-dedicated/tr_model.cpp
+++ b/codemp/rd-dedicated/tr_model.cpp
@@ -1024,7 +1024,7 @@ Ghoul2 Insert End
 			if ( strrchr( filename, '.' ) ) {
 				*strrchr( filename, '.' ) = 0;
 			}
-			sprintf( namebuf, "_%d.md3", lod );
+			Com_sprintf( namebuf, sizeof(namebuf), "_%d.md3", lod );
 			strcat( filename, namebuf );
 		}
 
@@ -1235,7 +1235,7 @@ Ghoul2 Insert End
 			if ( strrchr( filename, '.' ) ) {
 				*strrchr( filename, '.' ) = 0;
 			}
-			sprintf( namebuf, "_%d.md3", lod );
+			Com_sprintf( namebuf, sizeof(namebuf), "_%d.md3", lod );
 			strcat( filename, namebuf );
 		}
 

--- a/codemp/rd-vanilla/tr_model.cpp
+++ b/codemp/rd-vanilla/tr_model.cpp
@@ -1089,7 +1089,7 @@ Ghoul2 Insert End
 			if ( strrchr( filename, '.' ) ) {
 				*strrchr( filename, '.' ) = 0;
 			}
-			sprintf( namebuf, "_%d.md3", lod );
+			Com_sprintf( namebuf, sizeof(namebuf), "_%d.md3", lod );
 			strcat( filename, namebuf );
 		}
 
@@ -1304,7 +1304,7 @@ Ghoul2 Insert End
 			if ( strrchr( filename, '.' ) ) {
 				*strrchr( filename, '.' ) = 0;
 			}
-			sprintf( namebuf, "_%d.md3", lod );
+			Com_sprintf( namebuf, sizeof(namebuf), "_%d.md3", lod );
 			strcat( filename, namebuf );
 		}
 

--- a/codemp/rd-vulkan/tr_model.cpp
+++ b/codemp/rd-vulkan/tr_model.cpp
@@ -1075,7 +1075,7 @@ Ghoul2 Insert End
 			if ( strrchr( filename, '.' ) ) {
 				*strrchr( filename, '.' ) = 0;
 			}
-			sprintf( namebuf, "_%d.md3", lod );
+			Com_sprintf( namebuf, sizeof(namebuf), "_%d.md3", lod );
 			strcat( filename, namebuf );
 		}
 
@@ -1286,7 +1286,7 @@ Ghoul2 Insert End
 			if ( strrchr( filename, '.' ) ) {
 				*strrchr( filename, '.' ) = 0;
 			}
-			sprintf( namebuf, "_%d.md3", lod );
+			Com_sprintf( namebuf, sizeof(namebuf), "_%d.md3", lod );
 			strcat( filename, namebuf );
 		}
 

--- a/codemp/rd-vulkan/tr_shade_calc.cpp
+++ b/codemp/rd-vulkan/tr_shade_calc.cpp
@@ -675,6 +675,8 @@ void RB_DeformTessGeometry( void ) {
 		case DEFORM_TEXT7:
 			DeformText( backEnd.refdef.text[ds->deformation - DEFORM_TEXT0] );
 			break;
+		default:
+			break;
 		}
 	}
 }

--- a/codemp/rd-vulkan/tr_shader.cpp
+++ b/codemp/rd-vulkan/tr_shader.cpp
@@ -3555,7 +3555,7 @@ static int CollapseMultitexture( unsigned int st0bits, shaderStage_t *st0, shade
 	}
 
 	// preserve lightmap style
-	if (st1->lightmapStyle)
+	if (st1->lightmapStyle[0])
 	{
 		st0->lightmapStyle[1] = st1->lightmapStyle[0];
 	}

--- a/codemp/rd-vulkan/vk_frame.cpp
+++ b/codemp/rd-vulkan/vk_frame.cpp
@@ -943,6 +943,8 @@ static void vk_begin_render_pass( VkRenderPass renderPass, VkFramebuffer frameBu
             case RENDER_PASS_REFRACTION:
                     clear_values[ (int)( vk.msaaActive ? 2 : 0 )  ].color = { { 0.0f, 0.0f, 0.0f, 1.0f } };
                 break;
+            default:
+                break;
         }
 #endif
 #ifndef USE_REVERSED_DEPTH

--- a/codemp/rd-vulkan/vk_info.cpp
+++ b/codemp/rd-vulkan/vk_info.cpp
@@ -87,7 +87,7 @@ const char *vk_result_string( VkResult code ) {
         CASE_STR(VK_ERROR_INVALID_SHADER_NV);
         CASE_STR(VK_ERROR_NOT_PERMITTED_EXT);
         default:
-            sprintf(buffer, "code %i", code);
+            Com_sprintf(buffer, sizeof(buffer), "code %i", code);
             return buffer;
     }
 }
@@ -173,7 +173,7 @@ const char *vk_shadertype_string( Vk_Shader_Type code ) {
         CASE_STR(TYPE_BLEND3_DST_COLOR_SRC_ALPHA);
         CASE_STR(TYPE_BLEND3_DST_COLOR_SRC_ALPHA_ENV);
         default:
-            sprintf(buffer, "code %i", code);
+            Com_sprintf(buffer, sizeof(buffer), "code %i", code);
             return buffer;
     }
 }

--- a/codemp/rd-vulkan/vk_shade_geometry.cpp
+++ b/codemp/rd-vulkan/vk_shade_geometry.cpp
@@ -311,6 +311,7 @@ void vk_bind_geometry( uint32_t flags )
 			case SF_MDX:		return vk_vbo_bind_geometry_ghoul2( flags );
 			case SF_VBO_MDVMESH:return vk_vbo_bind_geometry_mdv( flags );
 			case SF_SPRITES:	return vk_vbo_bind_geometry_surface_sprites( flags );
+			default:			break;
 		}
 	}
 

--- a/codemp/rd-vulkan/vk_swapchain.cpp
+++ b/codemp/rd-vulkan/vk_swapchain.cpp
@@ -70,7 +70,7 @@ static const char *vk_pmode_to_str( VkPresentModeKHR mode )
         case VK_PRESENT_MODE_FIFO_KHR:          return "FIFO";
         case VK_PRESENT_MODE_FIFO_RELAXED_KHR:  return "FIFO_RELAXED";
         case VK_PRESENT_MODE_FIFO_LATEST_READY_EXT: return "FIFO_LATEST_READY";
-        default: sprintf(buf, "mode#%x", mode); return buf;
+        default: Com_sprintf(buf, sizeof(buf), "mode#%x", mode); return buf;
     };
 }
 

--- a/codemp/rd-vulkan/vk_vbo_surfacesprites.cpp
+++ b/codemp/rd-vulkan/vk_vbo_surfacesprites.cpp
@@ -516,6 +516,8 @@ static uint32_t vk_surface_sprites_create_vertex_data( const msurface_t *surf, f
 		case SF_TRIANGLES:
 			vk_surface_sprites_create_vertex_data_tri( (srfTriangles_t*)surf->data, density, stage, sprites, &count, &color, vertexLit );
 			break;
+		default:
+			break;
 	}
 
 	return count;

--- a/shared/rd-rend2/tr_local.h
+++ b/shared/rd-rend2/tr_local.h
@@ -3554,10 +3554,10 @@ public:
 		: ident(SF_MDX)
 		, boneCache(nullptr)
 		, vboMesh(nullptr)
-		, surfaceData(nullptr)
+		, genShadows(qfalse)
 		, dlightBits(0)
 		, pshadowBits(0)
-		, genShadows(qfalse)
+		, surfaceData(nullptr)
 #ifdef _G2_GORE
 		, alternateTex(nullptr)
 		, goreChain(nullptr)


### PR DESCRIPTION
- (vk/engine) converts various sprintf() calls to com_sprintf()
- converts incorrtect sprintf() usage to q_strncpyz
- (rend2) fixes constructor parameter order
- (vk) fixes struct array member in boolean check always resulting in 'true'

note that most of these changes are not likely to result in a bugfix, just improved developer experience when compiling with clang, as these warnings will no longer be spammed in the build log.