### PR TITLE
Add option to toggle unfocused chat bubble

### DIFF
--- a/codemp/client/cl_input.cpp
+++ b/codemp/client/cl_input.cpp
@@ -1261,8 +1261,10 @@ void CL_CmdButtons( usercmd_t *cmd ) {
 		}
 	}
 
-	if ( Key_GetCatcher( ) || com_unfocused->integer || com_minimized->integer ) {
-		cmd->buttons |= BUTTON_TALK;
+	if ( Key_GetCatcher() || ((com_unfocused->integer || com_minimized->integer) && cl_chatBubbleUnfocused->integer) ) {
+		if ( cl_chatBubbleSelf->integer ) {
+			cmd->buttons |= BUTTON_TALK;
+		}
 	}
 
 	// allow the game to know if any key at all is
@@ -1828,6 +1830,9 @@ void CL_InitInput( void ) {
 	cl_debugMove = Cvar_Get ("cl_debugMove", "0", 0);
 
 	cl_idrive = Cvar_Get ("cl_idrive", "0", CVAR_ARCHIVE);//JAPRO ENGINE
+
+	cl_chatBubbleUnfocused  = Cvar_Get ("cl_chatBubbleUnfocused", "1", CVAR_ARCHIVE);
+	cl_chatBubbleSelf  = Cvar_Get ("cl_chatBubbleSelf", "1", CVAR_ARCHIVE);
 }
 
 /*

--- a/codemp/client/cl_main.cpp
+++ b/codemp/client/cl_main.cpp
@@ -130,6 +130,9 @@ cvar_t  *cl_afkPrefix;
 cvar_t	*cl_afkTime;
 cvar_t	*cl_afkTimeUnfocused;
 
+cvar_t	*cl_chatBubbleUnfocused;
+cvar_t	*cl_chatBubbleSelf;
+
 cvar_t	*cl_logChat;
 
 #if defined(DISCORD) && !defined(_DEBUG)

--- a/codemp/client/client.h
+++ b/codemp/client/client.h
@@ -493,6 +493,9 @@ extern cvar_t	*cl_afkPrefix;
 extern cvar_t	*cl_afkTime;
 extern cvar_t	*cl_afkTimeUnfocused;
 
+extern	cvar_t	*cl_chatBubbleUnfocused;
+extern	cvar_t	*cl_chatBubbleSelf;
+
 extern cvar_t	*cl_logChat;
 
 #if defined(DISCORD) && !defined(_DEBUG)


### PR DESCRIPTION
Related issue: #300 
Implementation details:
`cl_chatBubbleUnfocused` which defaults to 1. When set to 0, the chat bubble with not draw while unfocused
`cl_chatBubbleSelf ` which defaults to 1. When set to 0, the chat bubble will never draw (in circumstances such as typing)

Reason:
For people wanting to make screenshots/cinematics/machinama