### PR TITLE
Add flipkick and grapple feature flag for servers that support flipkick and grapple

### DIFF
--- a/codemp/game/bg_pmove.c
+++ b/codemp/game/bg_pmove.c
@@ -310,11 +310,11 @@ static int GetFixRoll(playerState_t *ps) {
 			}
 		}
 
-		if ((cgs.serverMod == SVMOD_JAPLUS && cgs.cinfo & JAPLUS_CINFO_FIXROLL3) || (cgs.serverMod == SVMOD_JAPRO && cgs.jcinfo & JAPRO_CINFO_FIXROLL3))
+		if ((cgs.serverMod == SVMOD_JAPLUS && cgs.cinfo & JAPLUS_CINFO_FIXROLL3) || (cgs.serverMod == SVMOD_JAPRO && cgs.jcinfo & JAPRO_CINFO_FIXROLL3) || (cgs.taystJKinfo & TAYSTJK_INFO_FIXROLL_3))
 			return 3;
-		if ((cgs.serverMod == SVMOD_JAPLUS && cgs.cinfo & JAPLUS_CINFO_FIXROLL2) || (cgs.serverMod == SVMOD_JAPRO && cgs.jcinfo & JAPRO_CINFO_FIXROLL2) || cgs.legacyProtocol)
+		if ((cgs.serverMod == SVMOD_JAPLUS && cgs.cinfo & JAPLUS_CINFO_FIXROLL2) || (cgs.serverMod == SVMOD_JAPRO && cgs.jcinfo & JAPRO_CINFO_FIXROLL2) || (cgs.taystJKinfo & TAYSTJK_INFO_FIXROLL_2) || cgs.legacyProtocol)
 			return 2;
-		if ((cgs.serverMod == SVMOD_JAPLUS && cgs.cinfo & JAPLUS_CINFO_FIXROLL1) || (cgs.serverMod == SVMOD_JAPRO && cgs.jcinfo & JAPRO_CINFO_FIXROLL1))
+		if ((cgs.serverMod == SVMOD_JAPLUS && cgs.cinfo & JAPLUS_CINFO_FIXROLL1) || (cgs.serverMod == SVMOD_JAPRO && cgs.jcinfo & JAPRO_CINFO_FIXROLL1) || (cgs.taystJKinfo & TAYSTJK_INFO_FIXROLL_1))
 			return 1;
 
 		return 0;

--- a/codemp/game/bg_pmove.c
+++ b/codemp/game/bg_pmove.c
@@ -268,6 +268,9 @@ static int GetFlipkick(playerState_t *ps) {
 		if (cgs.serverMod == SVMOD_JAPLUS && (cgs.cinfo & JAPLUS_CINFO_FLIPKICK))
 			return 1;
 
+		if (cgs.taystJKinfo & TAYSTJK_INFO_FLIPKICK)
+			return 1;
+
 		return 0;
 #endif
 }

--- a/codemp/game/bg_pmove.c
+++ b/codemp/game/bg_pmove.c
@@ -15398,7 +15398,7 @@ void PmoveSingle (pmove_t *pmove) {
 #else
 			else if ((pm->ps->pm_flags & PMF_GRAPPLE) && !(pm->ps->pm_flags & PMF_DUCKED) && cgs.serverMod != SVMOD_JAPLUS && (!(cgs.jcinfo & JAPRO_CINFO_JAPLUSGRAPPLE) || IsRacemode(pm->ps)))
 				PM_GrappleMoveTarzan();
-			else if ((pm->ps->pm_flags & PMF_GRAPPLE) && !(pm->ps->pm_flags & PMF_DUCKED) && (cgs.serverMod == SVMOD_JAPLUS || (cgs.jcinfo & JAPRO_CINFO_JAPLUSGRAPPLE)))
+			else if ((pm->ps->pm_flags & PMF_GRAPPLE) && !(pm->ps->pm_flags & PMF_DUCKED) && (cgs.serverMod == SVMOD_JAPLUS || (cgs.jcinfo & JAPRO_CINFO_JAPLUSGRAPPLE) || cgs.taystJKinfo & TAYSTJK_INFO_GRAPPLE))
 				PM_GrappleMove();
 #endif
 

--- a/codemp/game/bg_public.h
+++ b/codemp/game/bg_public.h
@@ -551,9 +551,10 @@ extern int bgForcePowerCost[NUM_FORCE_POWERS][NUM_FORCE_POWER_LEVELS];
 #define TAYSTJK_INFO_BLACKSABERS            (1<<1)
 #define TAYSTJK_INFO_FLIPKICK	            (1<<2)
 #define TAYSTJK_INFO_GRAPPLE	            (1<<3)
-//todo:
-// #define TAYSTJK_INFO_JK2ROLL	            (1<<4)
-
+#define TAYSTJK_INFO_FIXROLL_1	            (1<<4) // enable rolling while using force grip (1.0.0)
+#define TAYSTJK_INFO_FIXROLL_2	            (1<<5) // enable rolling while using force grip + chaining rolls
+#define TAYSTJK_INFO_FIXROLL_3	            (1<<6) // jk2 roll
+#define TAYSTJK_INFO_HEADSLIDE				(1<<7)
 
 #define _SPPHYSICS 1
 #define _COOP 1

--- a/codemp/game/bg_public.h
+++ b/codemp/game/bg_public.h
@@ -550,6 +550,9 @@ extern int bgForcePowerCost[NUM_FORCE_POWERS][NUM_FORCE_POWER_LEVELS];
 #define TAYSTJK_INFO_RGBSABERS              (1<<0)
 #define TAYSTJK_INFO_BLACKSABERS            (1<<1)
 #define TAYSTJK_INFO_FLIPKICK	            (1<<2)
+#define TAYSTJK_INFO_GRAPPLE	            (1<<3)
+//todo:
+// #define TAYSTJK_INFO_JK2ROLL	            (1<<4)
 
 
 #define _SPPHYSICS 1

--- a/codemp/game/bg_public.h
+++ b/codemp/game/bg_public.h
@@ -549,6 +549,8 @@ extern int bgForcePowerCost[NUM_FORCE_POWERS][NUM_FORCE_POWER_LEVELS];
 //taystjk feature flags
 #define TAYSTJK_INFO_RGBSABERS              (1<<0)
 #define TAYSTJK_INFO_BLACKSABERS            (1<<1)
+#define TAYSTJK_INFO_FLIPKICK	            (1<<2)
+
 
 #define _SPPHYSICS 1
 #define _COOP 1


### PR DESCRIPTION
Flipkick, grapple, fixroll featureflags. 
Fixrolls follows the japlus standard where:
```
#define TAYSTJK_INFO_FIXROLL_1	            (1<<4) // enable rolling while using force grip (1.0.0)
#define TAYSTJK_INFO_FIXROLL_2	            (1<<5) // enable rolling while using force grip + chaining rolls
#define TAYSTJK_INFO_FIXROLL_3	            (1<<6) // jk2 roll
```

Needs testing