### PR TITLE
UI cosmetics support

### DIFF
--- a/assets/japro/ui/jamp/ingame_player2.menu
+++ b/assets/japro/ui/jamp/ingame_player2.menu
@@ -787,7 +787,7 @@
 		}
 		
 		// BACK button 
-		itemDef 
+		itemDef
 		{
 			name				backmenu_button
 			text				@MENUS_BACK
@@ -804,22 +804,71 @@
 			forecolor			1 .682 0 1
 			visible				1
 
-			mouseEnter 
-			{ 
+			mouseEnter
+			{
 				show			backButton
 			}
-			mouseExit 
-			{ 
+			mouseExit
+			{
 				hide			backButton
 			}
-			  	  
-			action 
-			{ 
-				play			"sound/interface/esc.wav" ; 
+
+			action
+			{
+				play			"sound/interface/esc.wav" ;
 				close			ingame_player2 ;
 				open			ingame_player ;
 			}
 
+		}
+
+//---------------------------------------------
+//	COSMETICS BUTTON
+//---------------------------------------------
+		itemDef
+		{
+			name				cosmeticsButton
+			group				highlights
+			style				WINDOW_STYLE_SHADER
+			rect				160 345 110 32
+			background			"gfx/menus/menu_buttonback"
+			forecolor			1 1 1 1
+			decoration
+			visible				0
+		}
+
+		itemDef
+		{
+			name				cosmeticsmenu_button
+			text				"Cosmetics"
+			descText			"Browse and equip hats and capes"
+			type				ITEM_TYPE_BUTTON
+			style				WINDOW_STYLE_EMPTY
+			rect				160 345 110 32
+			font				2
+			textscale			.9
+			textalign			ITEM_ALIGN_CENTER
+			textstyle			3
+			textalignx			55
+			textaligny			2
+			forecolor			1 .682 0 1
+			visible				1
+
+			mouseEnter
+			{
+				show			cosmeticsButton
+			}
+			mouseExit
+			{
+				hide			cosmeticsButton
+			}
+
+			action
+			{
+				play			"sound/interface/button1.wav"
+				close			ingame_player2
+				open			ingame_player_cosmetics
+			}
 		}
 		
 //---------------------------------------------

--- a/assets/japro/ui/jamp/ingame_player_cosmetics.menu
+++ b/assets/japro/ui/jamp/ingame_player_cosmetics.menu
@@ -1,0 +1,372 @@
+//-----------------------------------
+// Player Cosmetics
+//-----------------------------------
+{
+	menuDef
+	{
+		name					"ingame_player_cosmetics"
+		visible					0
+		fullscreen				0
+		outOfBoundsClick
+		rect					105 40 430 425
+		focusColor				1 1 1 1
+		style					1
+		border					1
+		descX					320
+		descY					450
+		descScale				1
+		descColor				1 .682 0 .8
+		descAlignment			ITEM_ALIGN_CENTER
+		onOpen
+		{
+			uiScript			"getcharcvars"
+			uiScript			"beginCosmeticPreview"
+			hide				highlights
+		}
+		onClose
+		{
+			hide				highlights
+		}
+
+// Window backdrop
+		itemDef
+		{
+			name				background_pic
+			group				none
+			style				WINDOW_STYLE_SHADER
+			rect				0 0 430 425
+			background			"gfx/menus/menu_box_ingame"
+			forecolor			1 1 1 1
+			visible				1
+			decoration
+		}
+
+// Title
+		itemDef
+		{
+			name				cosmeticstitle
+			style				WINDOW_STYLE_SHADER
+			background			"gfx/menus/menu_blendbox"
+			text				"Cosmetics"
+			rect				35 5 360 28
+			textalign			ITEM_ALIGN_CENTER
+			textalignx			180
+			textaligny			2
+			outlinecolor		1 .5 .5 .5
+			backcolor			0 0 0 0
+			font				3
+			textscale			0.9
+			forecolor			.549 .854 1 1
+			border				0
+			bordercolor			0 0 0 0
+			visible				1
+		}
+
+//----------------------------------------
+// Player preview
+//----------------------------------------
+		itemDef
+		{
+			name				character
+			group				models
+			type				ITEM_TYPE_MODEL
+			rect				270 84 200 225
+			model_g2anim		"BOTH_STAND1"
+			model_angle			180
+			model_g2mins		-30 -15 -14
+			model_g2maxs		20 15 30
+			model_rotation		50
+			model_fovx			50
+			model_fovy			50
+			isCharacter			1
+			visible				1
+			decoration
+		}
+
+//----------------------------------------
+// CATEGORY label
+//----------------------------------------
+		itemDef
+		{
+			name				category
+			group				none
+			type				ITEM_TYPE_BUTTON
+			style				WINDOW_STYLE_EMPTY
+			rect				15 48 180 24
+			forecolor			.549 .854 1 1
+			text				"Category"
+			textalign			ITEM_ALIGN_LEFT
+			textalignx			0
+			textaligny			-1
+			font				3
+			textscale			1
+			visible				1
+			decoration
+		}
+
+//----------------------------------------
+// HATS tab button
+//----------------------------------------
+		itemDef
+		{
+			name				hatsbut_glow
+			group				none
+			style				WINDOW_STYLE_SHADER
+			rect				15 80 90 16
+			background			"gfx/menus/menu_buttonback"
+			forecolor			1 1 1 1
+			visible				0
+			decoration
+		}
+
+		itemDef
+		{
+			name				hatsbut
+			group				none
+			text				"Hats"
+			descText			"Browse hats"
+			type				ITEM_TYPE_BUTTON
+			style				WINDOW_STYLE_EMPTY
+			rect				15 80 90 16
+			font				2
+			textscale			.9
+			textaligny			-5
+			textalign			ITEM_ALIGN_LEFT
+			textstyle			0
+			textalignx			0
+			backcolor			0 0 0 0
+			forecolor			1 .682 0 1
+			visible				1
+
+			mouseEnter
+			{
+				show			hatsbut_glow
+			}
+			mouseExit
+			{
+				hide			hatsbut_glow
+			}
+			action
+			{
+				play			"sound/interface/button1.wav"
+				show			hats
+				hide			capes
+			}
+		}
+
+//----------------------------------------
+// CAPES tab button
+//----------------------------------------
+		itemDef
+		{
+			name				capesbut_glow
+			group				none
+			style				WINDOW_STYLE_SHADER
+			rect				111 80 90 16
+			background			"gfx/menus/menu_buttonback"
+			forecolor			1 1 1 1
+			visible				0
+			decoration
+		}
+
+		itemDef
+		{
+			name				capesbut
+			group				none
+			text				"Capes"
+			descText			"Browse capes"
+			type				ITEM_TYPE_BUTTON
+			style				WINDOW_STYLE_EMPTY
+			rect				111 80 90 16
+			font				2
+			textscale			.9
+			textaligny			-5
+			textalign			ITEM_ALIGN_LEFT
+			textstyle			0
+			textalignx			0
+			backcolor			0 0 0 0
+			forecolor			1 .682 0 1
+			visible				1
+
+			mouseEnter
+			{
+				show			capesbut_glow
+			}
+			mouseExit
+			{
+				hide			capesbut_glow
+			}
+			action
+			{
+				play			"sound/interface/button1.wav"
+				show			capes
+				hide			hats
+			}
+		}
+
+//----------------------------------------
+// HATS listbox
+//----------------------------------------
+		itemDef
+		{
+			name				hatslistbox
+			group				hats
+			rect				15 110 240 200
+			type				ITEM_TYPE_LISTBOX
+			style				WINDOW_STYLE_FILLED
+			elementwidth		200
+			elementheight		17
+			font				2
+			textscale			.75
+			elementtype			LISTBOX_TEXT
+			feeder				FEEDER_COSMETIC_HATS
+			textstyle			6
+			textalign			3
+			textaligny			2
+			border				1
+			bordercolor			.5 .5 .5 1
+			forecolor			.615 .615 .956 1
+			backcolor			0 0 .5 .25
+			outlinecolor		.25 .464 .578 .5
+			descText			"Click to equip"
+			visible				1
+			columns				1 2 200 250
+			action
+			{
+				play			"sound/interface/button1.wav"
+			}
+		}
+
+//----------------------------------------
+// CAPES listbox
+//----------------------------------------
+		itemDef
+		{
+			name				capeslistbox
+			group				capes
+			rect				15 110 240 200
+			type				ITEM_TYPE_LISTBOX
+			style				WINDOW_STYLE_FILLED
+			elementwidth		200
+			elementheight		17
+			font				2
+			textscale			.75
+			elementtype			LISTBOX_TEXT
+			feeder				FEEDER_COSMETIC_CAPES
+			textstyle			6
+			textalign			3
+			textaligny			2
+			border				1
+			bordercolor			.5 .5 .5 1
+			forecolor			.615 .615 .956 1
+			backcolor			0 0 .5 .25
+			outlinecolor		.25 .464 .578 .5
+			descText			"Click to equip"
+			visible				0
+			columns				1 2 200 250
+			action
+			{
+				play			"sound/interface/button1.wav"
+			}
+		}
+
+//----------------------------------------
+// BACK button
+//----------------------------------------
+		itemDef
+		{
+			name				backButton
+			group				highlights
+			style				WINDOW_STYLE_SHADER
+			rect				30 370 110 32
+			background			"gfx/menus/menu_buttonback"
+			forecolor			1 1 1 1
+			decoration
+			visible				0
+		}
+
+		itemDef
+		{
+			name				backmenu_button
+			text				@MENUS_BACK
+			descText			"Discard changes and return"
+			type				ITEM_TYPE_BUTTON
+			style				WINDOW_STYLE_EMPTY
+			rect				30 370 110 32
+			font				2
+			textscale			.9
+			textalign			ITEM_ALIGN_CENTER
+			textstyle			3
+			textalignx			55
+			textaligny			2
+			forecolor			1 .682 0 1
+			visible				1
+
+			mouseEnter
+			{
+				show			backButton
+			}
+			mouseExit
+			{
+				hide			backButton
+			}
+
+			action
+			{
+				play			"sound/interface/esc.wav"
+				close			ingame_player_cosmetics
+				open			ingame_player2
+			}
+		}
+
+//----------------------------------------
+// APPLY button
+//----------------------------------------
+		itemDef
+		{
+			name				applyButton
+			group				highlights
+			style				WINDOW_STYLE_SHADER
+			rect				290 370 110 32
+			background			"gfx/menus/menu_buttonback"
+			forecolor			1 1 1 1
+			decoration
+			visible				0
+		}
+
+		itemDef
+		{
+			name				applymenu_button
+			text				@MENUS_APPLY
+			descText			"Equip selected cosmetics"
+			type				ITEM_TYPE_BUTTON
+			style				WINDOW_STYLE_EMPTY
+			rect				290 370 110 32
+			font				2
+			textscale			.9
+			textalign			ITEM_ALIGN_CENTER
+			textstyle			3
+			textalignx			55
+			textaligny			2
+			forecolor			1 .682 0 1
+			visible				1
+
+			mouseEnter
+			{
+				show			applyButton
+			}
+			mouseExit
+			{
+				hide			applyButton
+			}
+
+			action
+			{
+				play			"sound/interface/button1.wav"
+				uiScript		"applyCosmetics"
+				close			ingame_player_cosmetics
+				open			ingame_player2
+			}
+		}
+	}
+}

--- a/assets/japro/ui/jamp/menudef.h
+++ b/assets/japro/ui/jamp/menudef.h
@@ -132,6 +132,9 @@ along with this program; if not, see <http://www.gnu.org/licenses/>.
 #define FEEDER_SABER_SINGLE_INFO			0x2b			// saber single
 #define FEEDER_SABER_STAFF_INFO				0x2c			// saber staff
 
+#define FEEDER_COSMETIC_HATS				0x2d			// list of locally available hat cosmetics
+#define FEEDER_COSMETIC_CAPES				0x2e			// list of locally available cape cosmetics
+
 
 // Xbox specific, hope no one minds
 #define FEEDER_XBL_ACCOUNTS					0xA0			// list of available XBL accounts

--- a/assets/japro/ui/jampingame.txt
+++ b/assets/japro/ui/jampingame.txt
@@ -20,6 +20,7 @@
 	loadMenu { "ui/jamp/ingame.menu"			}
 	loadMenu { "ui/jamp/ingame_player.menu"			}
 	loadMenu { "ui/jamp/ingame_player2.menu"		}
+	loadMenu { "ui/jamp/ingame_player_cosmetics.menu"	}
 	loadMenu { "ui/jamp/ingame_playerforce.menu"		}
 
 	loadMenu { "ui/jamp/ingame_saber.menu"			}

--- a/codemp/cgame/CMakeLists.txt
+++ b/codemp/cgame/CMakeLists.txt
@@ -33,6 +33,7 @@ endif(WIN32)
 set(MPCGameDefines ${MPSharedDefines} "_CGAME" )
 set(MPCGameGameFiles
 	"${MPDir}/game/AnimalNPC.c"
+	"${MPDir}/game/bg_cosmetics.c"
 	"${MPDir}/game/bg_g2_utils.c"
 	"${MPDir}/game/bg_misc.c"
 	"${MPDir}/game/bg_panimate.c"
@@ -47,6 +48,7 @@ set(MPCGameGameFiles
 	"${MPDir}/game/SpeederNPC.c"
 	"${MPDir}/game/WalkerNPC.c"
 	"${MPDir}/game/anims.h"
+	"${MPDir}/game/bg_cosmetics.h"
 	"${MPDir}/game/bg_local.h"
 	"${MPDir}/game/bg_public.h"
 	"${MPDir}/game/bg_saga.h"

--- a/codemp/cgame/cg_consolecmds.c
+++ b/codemp/cgame/cg_consolecmds.c
@@ -1842,7 +1842,7 @@ static void CG_Cosmetics(void)
 				{
 					dynTable_addCell(va("%i", i));
 					dynTable_addCell(cosItems[i].name);
-					if (!Q_stricmp(cosItems[i].name, ciCosItem->name))
+					if (ciCosItem && !Q_stricmp(cosItems[i].name, ciCosItem->name))
 					{
 						dynTable_addCell("X");
 					}

--- a/codemp/cgame/cg_consolecmds.c
+++ b/codemp/cgame/cg_consolecmds.c
@@ -1748,25 +1748,6 @@ static void CG_Cosmetics_JaPRO(void)
 	}
 }
 
-cosmeticItem_t *CG_CosmeticForName(const char *name, cosmeticItem_t *cosmetics, int amount)
-{
-	int i ;
-
-	if (!name || !name[0])
-	{
-		return NULL;
-	}
-
-	for (i = 0; i < amount; i++)
-	{
-		if (!Q_stricmp(cosmetics[i].name, name))
-		{
-			return &cosmetics[i];
-		}
-	}
-	return NULL;
-}
-
 static void CG_Cosmetics(void)
 {
 	int argCount = trap->Cmd_Argc();

--- a/codemp/cgame/cg_consolecmds.c
+++ b/codemp/cgame/cg_consolecmds.c
@@ -1793,14 +1793,14 @@ static void CG_Cosmetics(void)
 			{
 				totalCosmetics = localCosmetics.totalHats;
 				cosItems = localCosmetics.hats;
-				ciCosItem = cgs.clientinfo[cg.clientNum].hat;
+				ciCosItem = &cgs.clientinfo[cg.clientNum].hat;
 				cvar = "color1";
 			}
 			else if (!Q_stricmp("Capes", arg))
 			{
 				totalCosmetics = localCosmetics.totalCapes;
 				cosItems = localCosmetics.capes;
-				ciCosItem = cgs.clientinfo[cg.clientNum].cape;
+				ciCosItem = &cgs.clientinfo[cg.clientNum].cape;
 				cvar = "color2";
 			}
 			else if (!Q_stricmp("Clear", arg))
@@ -1842,7 +1842,7 @@ static void CG_Cosmetics(void)
 				{
 					dynTable_addCell(va("%i", i));
 					dynTable_addCell(cosItems[i].name);
-					if (ciCosItem && !Q_stricmp(cosItems[i].name, ciCosItem->name))
+					if (ciCosItem->handle && !Q_stricmp(cosItems[i].name, ciCosItem->name))
 					{
 						dynTable_addCell("X");
 					}
@@ -1881,7 +1881,7 @@ static void CG_Cosmetics(void)
 
 				trap->Cvar_VariableStringBuffer(cvar, cvarValue, sizeof(cvarValue));
 
-				if (ciCosItem != item)
+				if (!ciCosItem->handle || Q_stricmp(ciCosItem->name, item->name))
 				{
 					Com_sprintf(cvarValue, sizeof(cvarValue), "%d%s", atoi(cvarValue), item->name);
 					trap->Cvar_Set(cvar, cvarValue);

--- a/codemp/cgame/cg_local.h
+++ b/codemp/cgame/cg_local.h
@@ -29,6 +29,7 @@ along with this program; if not, see <http://www.gnu.org/licenses/>.
 #include "game/bg_public.h"
 #include "cg_public.h"
 #include "qcommon/q_version.h"
+#include "game/bg_cosmetics.h"
 
 
 // The entire cgame module is unloaded and reloaded on each level change,
@@ -196,8 +197,6 @@ along with this program; if not, see <http://www.gnu.org/licenses/>.
 #define	JAPRO_COSMETIC_PREDATOR		(1<<30)
 #define	JAPRO_COSMETIC_SAIYAN		(1<<31)
 
-typedef struct cosmeticItem_s cosmeticItem_t;
-
 typedef enum //server mod enum
 {
 	SVMOD_BASEJKA,
@@ -317,29 +316,6 @@ typedef struct playerEntity_s {
 #define DEFAULT_FEMALE_SOUNDPATH "chars/mp_generic_female/misc"//"chars/tavion/misc"
 
 #define DEFAULT_MALE_SOUNDPATH "chars/mp_generic_male/misc"//"chars/kyle/misc"
-
-//Let's use 14 bytes because OpenJK and JA++ game modules both use 16 bytes buffer for color1, so if we support up to 16 only, we can pretty much use this on any server.
-//The remaining 2 bytes are to support the actual saber colors, since TaystJK supports up to 12 colors, we need to reserve 2 bytes for the color.
-#define MAX_COSMETIC_LENGTH 14
-
-#define COSMETIC_HATS_PATH "models/cosmetics/hats/"
-#define COSMETIC_HATS_PATH_LENGTH strlen(COSMETIC_HATS_PATH)
-#define COSMETIC_HATS_SETTINGS_PATH "settings/cosmetics/hats/"
-#define COSMETIC_HATS_SETTINGS_PATH_LENGTH strlen(COSMETIC_HATS_SETTINGS_PATH)
-
-#define COSMETIC_CAPES_PATH "models/cosmetics/capes/"
-#define COSMETIC_CAPES_PATH_LENGTH strlen(COSMETIC_CAPES_PATH)
-#define COSMETIC_CAPES_SETTINGS_PATH "settings/cosmetics/capes/"
-#define COSMETIC_CAPES_SETTINGS_PATH_LENGTH strlen(COSMETIC_CAPES_SETTINGS_PATH)
-
-struct cosmeticItem_s
-{
-	char name[MAX_COSMETIC_LENGTH];
-	qhandle_t handle;
-	int xOffset;
-	int yOffset;
-	int zOffset;
-};
 
 typedef struct clientInfo_s {
 	qboolean		infoValid;
@@ -1027,15 +1003,7 @@ typedef struct chatBoxItem_s
 	chatBoxEmoji_t emoji[MAX_CHATBOX_ITEM_EMOJIS];
 } chatBoxItem_t;
 
-typedef struct cosmetics_s
-{
-	cosmeticItem_t *hats;
-	cosmeticItem_t *capes;
-	int totalHats;
-	int totalCapes;
-} cosmetics_t;
-
-cosmetics_t localCosmetics;
+extern cosmetics_t localCosmetics;
 
 #define	MAX_CLIENT_SPEEDPOINTS		32
 typedef struct clientSpeedpoint_s
@@ -2675,7 +2643,6 @@ void CG_DrawOldTourneyScoreboard( void );
 //
 qboolean CG_ConsoleCommand( void );
 void CG_InitConsoleCommands( void );
-cosmeticItem_t *CG_CosmeticForName(const char *name, cosmeticItem_t *cosmetics, int amount);
 
 //
 // cg_servercmds.c

--- a/codemp/cgame/cg_local.h
+++ b/codemp/cgame/cg_local.h
@@ -332,6 +332,15 @@ typedef struct playerEntity_s {
 #define COSMETIC_CAPES_SETTINGS_PATH "settings/cosmetics/capes/"
 #define COSMETIC_CAPES_SETTINGS_PATH_LENGTH strlen(COSMETIC_CAPES_SETTINGS_PATH)
 
+struct cosmeticItem_s
+{
+	char name[MAX_COSMETIC_LENGTH];
+	qhandle_t handle;
+	int xOffset;
+	int yOffset;
+	int zOffset;
+};
+
 typedef struct clientInfo_s {
 	qboolean		infoValid;
 
@@ -448,8 +457,8 @@ typedef struct clientInfo_s {
 	vec3_t		rgb1, rgb2;//rgb sabers, use different ones for strafetrails. oh no.
 
 	unsigned int	cosmetics;
-	cosmeticItem_t	*hat;
-	cosmeticItem_t	*cape;
+	cosmeticItem_t	hat;
+	cosmeticItem_t	cape;
 
 #define _STRAFETRAILS 0
 #if _STRAFETRAILS
@@ -1017,15 +1026,6 @@ typedef struct chatBoxItem_s
 	int				lines;
 	chatBoxEmoji_t emoji[MAX_CHATBOX_ITEM_EMOJIS];
 } chatBoxItem_t;
-
-struct cosmeticItem_s
-{
-	char name[MAX_COSMETIC_LENGTH];
-	qhandle_t handle;
-	int xOffset;
-	int yOffset;
-	int zOffset;
-};
 
 typedef struct cosmetics_s
 {

--- a/codemp/cgame/cg_main.c
+++ b/codemp/cgame/cg_main.c
@@ -2855,7 +2855,12 @@ static void CG_LoadCosmetics(const char *path, int pathLen, int *totalCosmetics,
 		j++;
 	}
 
-	if (j < fileCnt)
+	if (j == 0)
+	{
+		free(cosmeticsPtr);
+		cosmeticsPtr = NULL;
+	}
+	else if (j < fileCnt)
 	{
 		cosmeticItem_t *temp = realloc(cosmeticsPtr, j * sizeof(*cosmeticsPtr));
 		if (!temp) trap->Error(ERR_DROP, S_COLOR_RED"ERROR: Failed to reallocate memory for cosmetics.\n");

--- a/codemp/cgame/cg_main.c
+++ b/codemp/cgame/cg_main.c
@@ -390,6 +390,8 @@ int					cg_numpermanents = 0;
 weaponInfo_t		cg_weapons[MAX_WEAPONS];
 itemInfo_t			cg_items[MAX_ITEMS];
 
+cosmetics_t			localCosmetics;
+
 int CG_CrosshairPlayer( void ) {
 	if ( cg.time > (cg.crosshairClientTime + 1000) )
 		return -1;
@@ -2799,87 +2801,6 @@ forceTicPos_t ammoTicPos[] =
 	{69 ,34 ,-10 ,10 ,"gfx/hud/ammo_tick7",0}
 };
 
-static void CG_LoadCosmetics(const char *path, int pathLen, int *totalCosmetics, cosmeticItem_t **storePtr) 
-{
-	int fileCnt, i, j, fileLen;
-	qhandle_t handle;
-	char cosmeticFiles[MAX_QPATH * 256]; //lets support 256 cosmetics for every category for now.
-	char cosmetic[MAX_QPATH];
-	cosmeticItem_t *cosmeticsPtr;
-	char *ptr;
-
-	fileCnt = trap->FS_GetFileList(path, ".md3", cosmeticFiles, sizeof(cosmeticFiles));
-
-	if (!fileCnt) return;
-
-	cosmeticsPtr = malloc(fileCnt * sizeof(*cosmeticsPtr));
-	if (!cosmeticsPtr) trap->Error(ERR_DROP, S_COLOR_RED"ERROR: Failed to allocate memory for cosmetics.\n");
-
-	ptr = cosmeticFiles;
-	j = 0;
-
-	for (i = 0; i < fileCnt; i++, ptr += fileLen + 1)
-	{
-		memset(cosmetic, 0, MAX_QPATH);
-		fileLen = strlen(ptr);
-
-		if ((pathLen + fileLen) > (MAX_QPATH - 1))
-		{
-			Com_Printf(S_COLOR_YELLOW"WARNING: Cosmetic [%s] path exceeded max length of %d, skipping...\n", ptr, MAX_QPATH - 1);
-			continue;
-		}
-
-		Q_strncpyz(cosmetic, ptr, sizeof(cosmetic));
-		COM_StripExtension(cosmetic, cosmetic, sizeof(cosmetic));
-
-		if (strlen(cosmetic) > (MAX_COSMETIC_LENGTH - 1))
-		{
-			Com_Printf(S_COLOR_YELLOW"WARNING: Cosmetic [%s] filename exceeded max length of %d, skipping...\n", cosmetic, MAX_COSMETIC_LENGTH - 1);
-			continue;
-		}
-
-		if (isdigit(cosmetic[0]))
-		{
-			Com_Printf(S_COLOR_YELLOW"WARNING: Cosmetic [%s] filename starts with a digit, skipping...\n", cosmetic);
-			continue;
-		}
-
-		handle = trap->R_RegisterModel(va("%s%s.md3", path, cosmetic));
-
-		if (!handle)
-		{
-			Com_Printf(S_COLOR_YELLOW"WARNING: Failed to register cosmetic [%s], skipping...\n", cosmetic);
-			continue;
-		}
-
-		Q_strncpyz(cosmeticsPtr[j].name, cosmetic, sizeof(cosmeticsPtr[j].name));
-		cosmeticsPtr[j].xOffset = cosmeticsPtr[j].yOffset = cosmeticsPtr[j].zOffset = 0;
-		cosmeticsPtr[j].handle = handle;
-		j++;
-	}
-
-	if (j == 0)
-	{
-		free(cosmeticsPtr);
-		cosmeticsPtr = NULL;
-	}
-	else if (j < fileCnt)
-	{
-		cosmeticItem_t *temp = realloc(cosmeticsPtr, j * sizeof(*cosmeticsPtr));
-		if (!temp) trap->Error(ERR_DROP, S_COLOR_RED"ERROR: Failed to reallocate memory for cosmetics.\n");
-		cosmeticsPtr = temp;
-	}
-
-	*storePtr = cosmeticsPtr;
-	*totalCosmetics = j;
-}
-
-static void CG_FreeCosmetics(void)
-{
-	if (localCosmetics.hats) free(localCosmetics.hats);
-	if (localCosmetics.capes) free(localCosmetics.capes);
-}
-
 /*
 =================
 CG_LoadEmojis
@@ -2999,9 +2920,7 @@ Ghoul2 Insert End
 	CG_LoadEmojis();
 
 	//Load cosmetics
-	CG_LoadCosmetics(COSMETIC_HATS_PATH, COSMETIC_HATS_PATH_LENGTH, &localCosmetics.totalHats, &localCosmetics.hats);
-	CG_LoadCosmetics(COSMETIC_CAPES_PATH, COSMETIC_CAPES_PATH_LENGTH, &localCosmetics.totalCapes, &localCosmetics.capes);
-
+	BG_LoadCosmetics(&localCosmetics);
 
 	//Load sabers.cfg data
 	WP_SaberLoadParms();
@@ -3337,7 +3256,7 @@ void CG_Shutdown( void )
 		CG_LogPrintf( cg.log.file, "End log\n----------------------------------------------------------------\n\n" );
 	CG_CloseLog( &cg.log.file);
 
-	CG_FreeCosmetics();
+	BG_FreeCosmetics(&localCosmetics);
 }
 
 /*

--- a/codemp/cgame/cg_main.c
+++ b/codemp/cgame/cg_main.c
@@ -2824,7 +2824,7 @@ static void CG_LoadCosmetics(const char *path, int pathLen, int *totalCosmetics,
 
 		if ((pathLen + fileLen) > (MAX_QPATH - 1))
 		{
-			Com_Printf(S_COLOR_YELLOW"WARNING: Cosmetic [%s] path exceeded max length of %d, skipping...\n", MAX_QPATH - 1);
+			Com_Printf(S_COLOR_YELLOW"WARNING: Cosmetic [%s] path exceeded max length of %d, skipping...\n", ptr, MAX_QPATH - 1);
 			continue;
 		}
 

--- a/codemp/cgame/cg_main.c
+++ b/codemp/cgame/cg_main.c
@@ -2838,12 +2838,6 @@ static void CG_LoadCosmetics(const char *path, int pathLen, int *totalCosmetics,
 			continue;
 		}
 
-		if (Q_isanumber(cosmetic))
-		{
-			Com_Printf(S_COLOR_YELLOW"WARNING: Cosmetic [%s] filename contains only digits, skipping...\n", cosmetic);
-			continue;
-		}
-
 		if (isdigit(cosmetic[0]))
 		{
 			Com_Printf(S_COLOR_YELLOW"WARNING: Cosmetic [%s] filename starts with a digit, skipping...\n", cosmetic);
@@ -2851,7 +2845,7 @@ static void CG_LoadCosmetics(const char *path, int pathLen, int *totalCosmetics,
 		}
 
 		handle = trap->R_RegisterModel(va("%s%s.md3", path, cosmetic));
-		
+
 		if (!handle)
 		{
 			Com_Printf(S_COLOR_YELLOW"WARNING: Failed to register cosmetic [%s], skipping...\n", cosmetic);

--- a/codemp/cgame/cg_main.c
+++ b/codemp/cgame/cg_main.c
@@ -2802,6 +2802,7 @@ forceTicPos_t ammoTicPos[] =
 static void CG_LoadCosmetics(const char *path, int pathLen, int *totalCosmetics, cosmeticItem_t **storePtr) 
 {
 	int fileCnt, i, j, fileLen;
+	qhandle_t handle;
 	char cosmeticFiles[MAX_QPATH * 256]; //lets support 256 cosmetics for every category for now.
 	char cosmetic[MAX_QPATH];
 	cosmeticItem_t *cosmeticsPtr;
@@ -2849,9 +2850,17 @@ static void CG_LoadCosmetics(const char *path, int pathLen, int *totalCosmetics,
 			continue;
 		}
 
+		handle = trap->R_RegisterModel(va("%s%s.md3", path, cosmetic));
+		
+		if (!handle)
+		{
+			Com_Printf(S_COLOR_YELLOW"WARNING: Failed to register cosmetic [%s], skipping...\n", cosmetic);
+			continue;
+		}
+
 		Q_strncpyz(cosmeticsPtr[j].name, cosmetic, sizeof(cosmeticsPtr[j].name));
 		cosmeticsPtr[j].xOffset = cosmeticsPtr[j].yOffset = cosmeticsPtr[j].zOffset = 0;
-		cosmeticsPtr[j].handle = trap->R_RegisterModel(va("%s%s.md3", path, cosmetic));
+		cosmeticsPtr[j].handle = handle;
 		j++;
 	}
 

--- a/codemp/cgame/cg_players.c
+++ b/codemp/cgame/cg_players.c
@@ -1756,7 +1756,7 @@ static void CG_SetDeferredClientInfo( clientInfo_t *ci ) {
 	CG_LoadClientInfo( ci );
 }
 
-void CG_validateCosmetic(const char *cosmeticPath, const char *cosName, cosmeticItem_t **ciCosmetic, cosmeticItem_t *localCosmetics, int totalCosmetics)
+void CG_validateCosmetic(const char *cosmeticPath, const char *cosName, cosmeticItem_t *ciCosmetic, cosmeticItem_t *localCosmetics, int totalCosmetics)
 {
 	fileHandle_t file;
 	char path[MAX_QPATH];
@@ -1764,16 +1764,16 @@ void CG_validateCosmetic(const char *cosmeticPath, const char *cosName, cosmetic
 	int i;
 	cosmeticItem_t *item = NULL;
 
+	memset(ciCosmetic, 0, sizeof(*ciCosmetic));
+
 	if (!Q_stricmp(cosName, "none")) //No hat.
 	{
-		*ciCosmetic = NULL;
 		return;
 	}
 
 	if (strlen(cosName) > (MAX_COSMETIC_LENGTH - 1))
 	{
 		Com_Printf(S_COLOR_YELLOW"WARNING: illegal cosmetic detected, skipping: [%s].\n", cosName);
-		*ciCosmetic = NULL;
 		return;
 	}
 
@@ -1788,7 +1788,6 @@ void CG_validateCosmetic(const char *cosmeticPath, const char *cosName, cosmetic
 
 	if (!item) //Cosmetic is not found.
 	{
-		item = NULL;
 		return;
 	}
 
@@ -1796,19 +1795,15 @@ void CG_validateCosmetic(const char *cosmeticPath, const char *cosName, cosmetic
 	Com_sprintf(path, sizeof(path), "%s%s.md3", cosmeticPath, item->name);
 	fileSize = trap->FS_Open(path, &file, FS_READ);
 
-	if (fileSize <= 0) // File Doesnt exist.
+	if (fileSize > 0) // File exists.
 	{
-		*ciCosmetic = NULL;
-	}
-	else
-	{
-		*ciCosmetic = item;
+		memcpy(ciCosmetic, item, sizeof(*ciCosmetic));
 	}
 
 	trap->FS_Close(file);
 }
 #define VALID_COSMETIC_OFFSETS(x, y, z) (cJSON_IsNumber(x) && cJSON_IsNumber(y) && cJSON_IsNumber(z))
-static void CG_LoadCustomCosmeticOffsets(const char *settingsPath, int pathLen, cosmeticItem_t **cosmetic, const char *model, const char *skin)
+static void CG_LoadCustomCosmeticOffsets(const char *settingsPath, int pathLen, cosmeticItem_t *cosmetic, const char *model, const char *skin)
 {
 	char fullPath[MAX_QPATH];
 	char *cosmeticName;
@@ -1816,9 +1811,9 @@ static void CG_LoadCustomCosmeticOffsets(const char *settingsPath, int pathLen, 
 	int fileSize, i;
 	qboolean modelFallback = qfalse; //Let's set the default value to false.
 
-	if (*cosmetic == NULL) return;
+	if (!cosmetic || !cosmetic->handle) return;
 
-	cosmeticName = (*cosmetic)->name;
+	cosmeticName = cosmetic->name;
 
 	if (pathLen + strlen(cosmeticName) + strlen("cosmetic") + 1 >= MAX_QPATH)
 	{
@@ -1831,7 +1826,7 @@ static void CG_LoadCustomCosmeticOffsets(const char *settingsPath, int pathLen, 
 
 	if (fileSize <= 0) //File doesn't exist.
 	{
-		(*cosmetic)->xOffset = (*cosmetic)->yOffset = (*cosmetic)->zOffset = 0;
+		cosmetic->xOffset = cosmetic->yOffset = cosmetic->zOffset = 0;
 		trap->FS_Close(file);
 	}
 	else
@@ -1858,7 +1853,7 @@ static void CG_LoadCustomCosmeticOffsets(const char *settingsPath, int pathLen, 
 		if (!json)
 		{
 			Com_Printf(S_COLOR_YELLOW"WARNING: Skipping custom offsets for cosmetic (%s), failed to parse JSON.\n", cosmeticName);
-			(*cosmetic)->xOffset = (*cosmetic)->yOffset = (*cosmetic)->zOffset = 0;
+			cosmetic->xOffset = cosmetic->yOffset = cosmetic->zOffset = 0;
 			free(buff);
 			return;
 		}
@@ -1899,7 +1894,7 @@ static void CG_LoadCustomCosmeticOffsets(const char *settingsPath, int pathLen, 
 			}
 			else
 			{
-				(*cosmetic)->xOffset = (*cosmetic)->yOffset = (*cosmetic)->zOffset = 0;
+				cosmetic->xOffset = cosmetic->yOffset = cosmetic->zOffset = 0;
 				cJSON_Delete(json);
 				free(buff);
 				return;
@@ -1958,14 +1953,14 @@ static void CG_LoadCustomCosmeticOffsets(const char *settingsPath, int pathLen, 
 					zOffset = cJSON_GetObjectItemCaseSensitive(jsonSkin, "zOffset");
 
 					if (VALID_COSMETIC_OFFSETS(xOffset, yOffset, zOffset)) {
-						(*cosmetic)->xOffset = xOffset->valueint;
-						(*cosmetic)->yOffset = yOffset->valueint;
-						(*cosmetic)->zOffset = zOffset->valueint;
+						cosmetic->xOffset = xOffset->valueint;
+						cosmetic->yOffset = yOffset->valueint;
+						cosmetic->zOffset = zOffset->valueint;
 					}
 					else
 					{
 						Com_Printf(S_COLOR_YELLOW"WARNING: Skipping custom offsets for cosmetic (%s), the skin (%s) JSON object does not contain valid offset values.\n", cosmeticName, jsonSkin->string);
-						(*cosmetic)->xOffset = (*cosmetic)->yOffset = (*cosmetic)->zOffset = 0;
+						cosmetic->xOffset = cosmetic->yOffset = cosmetic->zOffset = 0;
 					}
 				}
 				else //No wildcard found, check if we should fallback to the model's offsets or not.
@@ -1977,19 +1972,19 @@ static void CG_LoadCustomCosmeticOffsets(const char *settingsPath, int pathLen, 
 						zOffset = cJSON_GetObjectItemCaseSensitive(jsonModel, "zOffset");
 
 						if (VALID_COSMETIC_OFFSETS(xOffset, yOffset, zOffset)) {
-							(*cosmetic)->xOffset = xOffset->valueint;
-							(*cosmetic)->yOffset = yOffset->valueint;
-							(*cosmetic)->zOffset = zOffset->valueint;
+							cosmetic->xOffset = xOffset->valueint;
+							cosmetic->yOffset = yOffset->valueint;
+							cosmetic->zOffset = zOffset->valueint;
 						}
 						else
 						{
 							Com_Printf(S_COLOR_YELLOW"WARNING: Skipping custom offsets for cosmetic (%s), the model (%s) JSON object does not contain valid offset values.\n", cosmeticName, jsonModel->string);
-							(*cosmetic)->xOffset = (*cosmetic)->yOffset = (*cosmetic)->zOffset = 0;
+							cosmetic->xOffset = cosmetic->yOffset = cosmetic->zOffset = 0;
 						}
 					}
 					else
 					{
-						(*cosmetic)->xOffset = (*cosmetic)->yOffset = (*cosmetic)->zOffset = 0;
+						cosmetic->xOffset = cosmetic->yOffset = cosmetic->zOffset = 0;
 					}
 				}
 			}
@@ -2000,14 +1995,14 @@ static void CG_LoadCustomCosmeticOffsets(const char *settingsPath, int pathLen, 
 				zOffset = cJSON_GetObjectItemCaseSensitive(jsonSkin, "zOffset");
 
 				if (VALID_COSMETIC_OFFSETS(xOffset, yOffset, zOffset)) {
-					(*cosmetic)->xOffset = xOffset->valueint;
-					(*cosmetic)->yOffset = yOffset->valueint;
-					(*cosmetic)->zOffset = zOffset->valueint;
+					cosmetic->xOffset = xOffset->valueint;
+					cosmetic->yOffset = yOffset->valueint;
+					cosmetic->zOffset = zOffset->valueint;
 				}
 				else
 				{
 					Com_Printf(S_COLOR_YELLOW"WARNING: Skipping custom offsets for cosmetic (%s),the skin (%s) JSON object does not contain valid offset values.\n", cosmeticName, jsonSkin->string);
-					(*cosmetic)->xOffset = (*cosmetic)->yOffset = (*cosmetic)->zOffset = 0;
+					cosmetic->xOffset = cosmetic->yOffset = cosmetic->zOffset = 0;
 				}
 			}
 		}
@@ -2092,16 +2087,9 @@ void CG_NewClientInfo( int clientNum, qboolean entitiesInitialized ) {
 	Q_StripDigits(v, cosmeticStr, sizeof(cosmeticStr), REMOVE_DIGITS_INITIAL);
 	if (*cosmeticStr)
 	{
-		if (ci->hat)
+		if (ci->hat.handle && !Q_stricmp(ci->hat.name, cosmeticStr))
 		{
-			if (Q_stricmp(ci->hat->name, cosmeticStr))
-			{
-				CG_validateCosmetic(COSMETIC_HATS_PATH, cosmeticStr, &newInfo.hat, localCosmetics.hats, localCosmetics.totalHats);
-			}
-			else
-			{
-				newInfo.hat = ci->hat;
-			}
+			newInfo.hat = ci->hat;
 		}
 		else
 		{
@@ -2110,7 +2098,7 @@ void CG_NewClientInfo( int clientNum, qboolean entitiesInitialized ) {
 	}
 	else
 	{
-		newInfo.hat = NULL;
+		memset(&newInfo.hat, 0, sizeof(newInfo.hat));
 	}
 
 	v = Info_ValueForKey( configstring, "c2" );
@@ -2122,16 +2110,9 @@ void CG_NewClientInfo( int clientNum, qboolean entitiesInitialized ) {
 	Q_StripDigits(v, cosmeticStr, sizeof(cosmeticStr), REMOVE_DIGITS_INITIAL);
 	if (*cosmeticStr)
 	{
-		if (ci->cape)
+		if (ci->cape.handle && !Q_stricmp(ci->cape.name, cosmeticStr))
 		{
-			if (Q_stricmp(ci->cape->name, cosmeticStr))
-			{
-				CG_validateCosmetic(COSMETIC_CAPES_PATH, cosmeticStr, &newInfo.cape, localCosmetics.capes, localCosmetics.totalCapes);
-			}
-			else
-			{
-				newInfo.cape = ci->cape;
-			}
+			newInfo.cape = ci->cape;
 		}
 		else
 		{
@@ -2140,7 +2121,7 @@ void CG_NewClientInfo( int clientNum, qboolean entitiesInitialized ) {
 	}
 	else
 	{
-		newInfo.cape = NULL;
+		memset(&newInfo.cape, 0, sizeof(newInfo.cape));
 	}
 
 	// bot skill
@@ -2192,9 +2173,9 @@ void CG_NewClientInfo( int clientNum, qboolean entitiesInitialized ) {
 	g = (full >> 8) & 255;
 	b = full >> 16;
 	if ( cg.clientNum == clientNum && newInfo.icolor1 == SABER_RGB ) {
-		if (newInfo.hat)
+		if (newInfo.hat.handle)
 		{
-			trap->Cvar_Set("color1", va("%i%s", SABER_RGB, newInfo.hat->name));
+			trap->Cvar_Set("color1", va("%i%s", SABER_RGB, newInfo.hat.name));
 		}
 		else
 		{
@@ -2214,9 +2195,9 @@ void CG_NewClientInfo( int clientNum, qboolean entitiesInitialized ) {
 	g = (full >> 8) & 255;
 	b = full >> 16;
 	if ( cg.clientNum == clientNum && newInfo.icolor2 == SABER_RGB ) {
-		if (newInfo.cape)
+		if (newInfo.cape.handle)
 		{
-			trap->Cvar_Set("color2", va("%i%s", SABER_RGB, newInfo.cape->name));
+			trap->Cvar_Set("color2", va("%i%s", SABER_RGB, newInfo.cape.name));
 		}
 		else
 		{
@@ -2318,11 +2299,21 @@ void CG_NewClientInfo( int clientNum, qboolean entitiesInitialized ) {
 	}
 
 	//Now that the model and skin are validated, we can load custom offsets for cosmetics if needed.
-	if ((newInfo.hat && newInfo.hat != ci->hat) || (Q_stricmp(newInfo.modelName, ci->modelName) && newInfo.hat) || (Q_stricmp(newInfo.skinName, ci->skinName) && newInfo.hat))
-	CG_LoadCustomCosmeticOffsets(COSMETIC_HATS_SETTINGS_PATH, COSMETIC_HATS_SETTINGS_PATH_LENGTH,&newInfo.hat, newInfo.modelName, newInfo.skinName);
+	if (newInfo.hat.handle &&
+		(Q_stricmp(newInfo.hat.name, ci->hat.name) ||
+		 Q_stricmp(newInfo.modelName, ci->modelName) ||
+		 Q_stricmp(newInfo.skinName, ci->skinName)))
+	{
+		CG_LoadCustomCosmeticOffsets(COSMETIC_HATS_SETTINGS_PATH, COSMETIC_HATS_SETTINGS_PATH_LENGTH, &newInfo.hat, newInfo.modelName, newInfo.skinName);
+	}
 
-	if ((newInfo.cape && newInfo.cape != ci->cape) || (Q_stricmp(newInfo.modelName, ci->modelName) && newInfo.cape) || (Q_stricmp(newInfo.skinName, ci->skinName) && newInfo.cape))
-	CG_LoadCustomCosmeticOffsets(COSMETIC_CAPES_SETTINGS_PATH, COSMETIC_CAPES_SETTINGS_PATH_LENGTH, &newInfo.cape, newInfo.modelName, newInfo.skinName);
+	if (newInfo.cape.handle &&
+		(Q_stricmp(newInfo.cape.name, ci->cape.name) ||
+		 Q_stricmp(newInfo.modelName, ci->modelName) ||
+		 Q_stricmp(newInfo.skinName, ci->skinName)))
+	{
+		CG_LoadCustomCosmeticOffsets(COSMETIC_CAPES_SETTINGS_PATH, COSMETIC_CAPES_SETTINGS_PATH_LENGTH, &newInfo.cape, newInfo.modelName, newInfo.skinName);
+	}
 
 	if (cgs.gametype == GT_SIEGE)
 	{ //entries only sent in siege mode
@@ -10207,7 +10198,7 @@ static void CG_DrawCosmeticOnPlayer2(centity_t* cent, int time, qhandle_t* gameM
 	vec3_t boltOrg, bAngles;
 	refEntity_t re;
 
-	if (!cosmetic)
+	if (!cosmetic || !cosmetic->handle)
 	{
 		return;
 	}
@@ -13178,8 +13169,9 @@ stillDoSaber:
 	//Cosmetics
 	if (!(cg_stylePlayer.integer & JAPRO_STYLE_HIDECOSMETICS))
 	{
-		cosmeticItem_t *hat = cg_forceCosmetics.integer ? cgs.clientinfo[cg.clientNum].hat : ci->hat;
-		cosmeticItem_t *cape = cg_forceCosmetics.integer ? cgs.clientinfo[cg.clientNum].cape : ci->cape;
+		clientInfo_t *src = cg_forceCosmetics.integer ? &cgs.clientinfo[cg.clientNum] : ci;
+		cosmeticItem_t *hat = src->hat.handle ? &src->hat : NULL;
+		cosmeticItem_t *cape = src->cape.handle ? &src->cape : NULL;
 
 		if ((cg_stylePlayer.integer & JAPRO_STYLE_SEASONALCOSMETICS))
 		{

--- a/codemp/cgame/cg_players.c
+++ b/codemp/cgame/cg_players.c
@@ -25,7 +25,6 @@ along with this program; if not, see <http://www.gnu.org/licenses/>.
 #include "cg_local.h"
 #include "ghoul2/G2.h"
 #include "game/bg_saga.h"
-#include "cJSON.h"
 #include "hud_tribes.h"
 
 extern int			cgSiegeTeam1PlShader;
@@ -1802,214 +1801,6 @@ void CG_validateCosmetic(const char *cosmeticPath, const char *cosName, cosmetic
 
 	trap->FS_Close(file);
 }
-#define VALID_COSMETIC_OFFSETS(x, y, z) (cJSON_IsNumber(x) && cJSON_IsNumber(y) && cJSON_IsNumber(z))
-static void CG_LoadCustomCosmeticOffsets(const char *settingsPath, int pathLen, cosmeticItem_t *cosmetic, const char *model, const char *skin)
-{
-	char fullPath[MAX_QPATH];
-	char *cosmeticName;
-	fileHandle_t file;
-	int fileSize, i;
-	qboolean modelFallback = qfalse; //Let's set the default value to false.
-
-	if (!cosmetic || !cosmetic->handle) return;
-
-	cosmeticName = cosmetic->name;
-
-	if (pathLen + strlen(cosmeticName) + strlen("cosmetic") + 1 >= MAX_QPATH)
-	{
-		Com_Printf(S_COLOR_YELLOW"WARNING: Skipping custom offsets for cosmetic (%s), path too long.\n", cosmeticName);
-		return;
-	}
-
-	Com_sprintf(fullPath, sizeof(fullPath),"%s%s.cosmetic", settingsPath, cosmeticName);
-	fileSize = trap->FS_Open(fullPath, &file, FS_READ);
-
-	if (fileSize <= 0) //File doesn't exist.
-	{
-		cosmetic->xOffset = cosmetic->yOffset = cosmetic->zOffset = 0;
-		trap->FS_Close(file);
-	}
-	else
-	{
-		char *buff = malloc((fileSize + 1) * sizeof(char));
-		cJSON *json;
-		cJSON *jsonModel;
-		cJSON *jsonSkin;
-		cJSON *jsonModelFallback;
-		cJSON *xOffset, *yOffset, *zOffset;
-
-		if (!buff)
-		{
-			trap->FS_Close(file);
-			trap->Error(ERR_DROP,S_COLOR_RED"ERROR: Failed to allocate memory of cosmetic offsets.\n");
-		}
-
-		trap->FS_Read(buff, fileSize, file);
-		buff[fileSize] = '\0';
-		trap->FS_Close(file);
-
-		json = cJSON_Parse(buff);
-
-		if (!json)
-		{
-			Com_Printf(S_COLOR_YELLOW"WARNING: Skipping custom offsets for cosmetic (%s), failed to parse JSON.\n", cosmeticName);
-			cosmetic->xOffset = cosmetic->yOffset = cosmetic->zOffset = 0;
-			free(buff);
-			return;
-		}
-
-		jsonModel = cJSON_GetObjectItemCaseSensitive(json, va("%s",model));
-
-		if (!jsonModel) // No custom offsets for the exact model have been been found, lets look for wildcard names.
-		{
-			char* ptr;
-			int longestLen = 0;
-			int skinLen = strlen(model);
-			int len;
-			int index = -1;
-
-			for (i = 0; i < cJSON_GetArraySize(json); i++)
-			{
-				cJSON* temp = cJSON_GetArrayItem(json, i);
-
-				if (!cJSON_IsObject(temp)) continue;
-				ptr = strchr(temp->string, '*');
-				if (!ptr) continue;
-				len = ptr - temp->string;
-
-				if (len <= skinLen && !strncmp(temp->string, model, len))
-				{
-					if (len > longestLen)
-					{
-						longestLen = len;
-						index = i;
-					}
-				}
-			}
-
-			if (index > -1) //We found a wildcard model.
-			{
-				jsonModel = cJSON_GetArrayItem(json, index);
-				goto foundValidModel;
-			}
-			else
-			{
-				cosmetic->xOffset = cosmetic->yOffset = cosmetic->zOffset = 0;
-				cJSON_Delete(json);
-				free(buff);
-				return;
-			}
-		}
-		else
-		{
-			foundValidModel:
-			jsonModelFallback = cJSON_GetObjectItem(jsonModel, "modelFallback");
-			if (cJSON_IsBool(jsonModelFallback))
-			{
-				if (cJSON_IsTrue(jsonModelFallback)) {
-					modelFallback = qtrue;
-				}
-				else
-				{
-					modelFallback = qfalse;
-				}
-			}
-
-			jsonSkin = cJSON_GetObjectItemCaseSensitive(jsonModel, va("%s", skin));
-
-			if (!jsonSkin) // No custom offsets for the exact skin have been been found, lets look for wildcard names.
-			{	
-				char *ptr;
-				int longestLen = 0;
-				int skinLen = strlen(skin);
-				int len;
-				int index = -1;
-
-				for (i = 0; i < cJSON_GetArraySize(jsonModel); i++)
-				{
-					cJSON *temp = cJSON_GetArrayItem(jsonModel, i);
-
-					if (!cJSON_IsObject(temp)) continue;
-					ptr = strchr(temp->string, '*');
-					if (!ptr) continue;
-					len = ptr - temp->string;
-
-					if (len <= skinLen && !strncmp(temp->string, skin, len))
-					{
-						if (len > longestLen)
-						{
-							longestLen = len;
-							index = i;
-						}
-					}
-				}
-
-				if (index > -1) //We found a wildcard skin.
-				{
-					jsonSkin = cJSON_GetArrayItem(jsonModel, index);
-
-					xOffset = cJSON_GetObjectItemCaseSensitive(jsonSkin, "xOffset");
-					yOffset = cJSON_GetObjectItemCaseSensitive(jsonSkin, "yOffset");
-					zOffset = cJSON_GetObjectItemCaseSensitive(jsonSkin, "zOffset");
-
-					if (VALID_COSMETIC_OFFSETS(xOffset, yOffset, zOffset)) {
-						cosmetic->xOffset = xOffset->valueint;
-						cosmetic->yOffset = yOffset->valueint;
-						cosmetic->zOffset = zOffset->valueint;
-					}
-					else
-					{
-						Com_Printf(S_COLOR_YELLOW"WARNING: Skipping custom offsets for cosmetic (%s), the skin (%s) JSON object does not contain valid offset values.\n", cosmeticName, jsonSkin->string);
-						cosmetic->xOffset = cosmetic->yOffset = cosmetic->zOffset = 0;
-					}
-				}
-				else //No wildcard found, check if we should fallback to the model's offsets or not.
-				{
-					if (modelFallback)
-					{
-						xOffset = cJSON_GetObjectItemCaseSensitive(jsonModel, "xOffset");
-						yOffset = cJSON_GetObjectItemCaseSensitive(jsonModel, "yOffset");
-						zOffset = cJSON_GetObjectItemCaseSensitive(jsonModel, "zOffset");
-
-						if (VALID_COSMETIC_OFFSETS(xOffset, yOffset, zOffset)) {
-							cosmetic->xOffset = xOffset->valueint;
-							cosmetic->yOffset = yOffset->valueint;
-							cosmetic->zOffset = zOffset->valueint;
-						}
-						else
-						{
-							Com_Printf(S_COLOR_YELLOW"WARNING: Skipping custom offsets for cosmetic (%s), the model (%s) JSON object does not contain valid offset values.\n", cosmeticName, jsonModel->string);
-							cosmetic->xOffset = cosmetic->yOffset = cosmetic->zOffset = 0;
-						}
-					}
-					else
-					{
-						cosmetic->xOffset = cosmetic->yOffset = cosmetic->zOffset = 0;
-					}
-				}
-			}
-			else
-			{
-				xOffset = cJSON_GetObjectItemCaseSensitive(jsonSkin, "xOffset");
-				yOffset = cJSON_GetObjectItemCaseSensitive(jsonSkin, "yOffset");
-				zOffset = cJSON_GetObjectItemCaseSensitive(jsonSkin, "zOffset");
-
-				if (VALID_COSMETIC_OFFSETS(xOffset, yOffset, zOffset)) {
-					cosmetic->xOffset = xOffset->valueint;
-					cosmetic->yOffset = yOffset->valueint;
-					cosmetic->zOffset = zOffset->valueint;
-				}
-				else
-				{
-					Com_Printf(S_COLOR_YELLOW"WARNING: Skipping custom offsets for cosmetic (%s),the skin (%s) JSON object does not contain valid offset values.\n", cosmeticName, jsonSkin->string);
-					cosmetic->xOffset = cosmetic->yOffset = cosmetic->zOffset = 0;
-				}
-			}
-		}
-		cJSON_Delete(json);
-		free(buff);
-	}
-}
 
 
 /*
@@ -2304,7 +2095,7 @@ void CG_NewClientInfo( int clientNum, qboolean entitiesInitialized ) {
 		 Q_stricmp(newInfo.modelName, ci->modelName) ||
 		 Q_stricmp(newInfo.skinName, ci->skinName)))
 	{
-		CG_LoadCustomCosmeticOffsets(COSMETIC_HATS_SETTINGS_PATH, COSMETIC_HATS_SETTINGS_PATH_LENGTH, &newInfo.hat, newInfo.modelName, newInfo.skinName);
+		BG_LoadCustomCosmeticOffsets(COSMETIC_HATS_SETTINGS_PATH, COSMETIC_HATS_SETTINGS_PATH_LENGTH, &newInfo.hat, newInfo.modelName, newInfo.skinName);
 	}
 
 	if (newInfo.cape.handle &&
@@ -2312,7 +2103,7 @@ void CG_NewClientInfo( int clientNum, qboolean entitiesInitialized ) {
 		 Q_stricmp(newInfo.modelName, ci->modelName) ||
 		 Q_stricmp(newInfo.skinName, ci->skinName)))
 	{
-		CG_LoadCustomCosmeticOffsets(COSMETIC_CAPES_SETTINGS_PATH, COSMETIC_CAPES_SETTINGS_PATH_LENGTH, &newInfo.cape, newInfo.modelName, newInfo.skinName);
+		BG_LoadCustomCosmeticOffsets(COSMETIC_CAPES_SETTINGS_PATH, COSMETIC_CAPES_SETTINGS_PATH_LENGTH, &newInfo.cape, newInfo.modelName, newInfo.skinName);
 	}
 
 	if (cgs.gametype == GT_SIEGE)
@@ -13176,11 +12967,11 @@ stillDoSaber:
 			//the months follow array indexing (0 = january, 11 = december)
 			if ((time.tm_mon == 10 && time.tm_mday > 21) || time.tm_mon == 11 || (time.tm_mon == 0 && time.tm_mday < 8)) { //Christmas
 				if (!ci->cosmetics) ci->cosmetics |= JAPRO_COSMETIC_SANTAHAT;
-				if (!hat) hat = CG_CosmeticForName("santahat", localCosmetics.hats, localCosmetics.totalHats);
+				if (!hat) hat = BG_FindCosmeticByName("santahat", localCosmetics.hats, localCosmetics.totalHats);
 			}
 			else if (time.tm_mon == 9 && time.tm_mday == 31) { //Halloween
 				if (!ci->cosmetics) ci->cosmetics |= JAPRO_COSMETIC_PUMKIN;
-				if (!hat) hat = CG_CosmeticForName("pumpkin", localCosmetics.hats, localCosmetics.totalHats);
+				if (!hat) hat = BG_FindCosmeticByName("pumpkin", localCosmetics.hats, localCosmetics.totalHats);
 			}
 		}
 

--- a/codemp/cgame/cg_players.c
+++ b/codemp/cgame/cg_players.c
@@ -1770,7 +1770,7 @@ void CG_validateCosmetic(const char *cosmeticPath, const char *cosName, cosmetic
 		return;
 	}
 
-	if (strlen(cosName) > MAX_COSMETIC_LENGTH)
+	if (strlen(cosName) > (MAX_COSMETIC_LENGTH - 1))
 	{
 		Com_Printf(S_COLOR_YELLOW"WARNING: illegal cosmetic detected, skipping: [%s].\n", cosName);
 		*ciCosmetic = NULL;

--- a/codemp/cgame/cg_players.c
+++ b/codemp/cgame/cg_players.c
@@ -10161,8 +10161,6 @@ void CG_DrawCosmeticOnPlayer(centity_t* cent, int time, qhandle_t* gameModels, q
     	BG_GiveMeVectorFromMatrix(&matrix, POSITIVE_Y, re.axis[1]); //right
     	BG_GiveMeVectorFromMatrix(&matrix, POSITIVE_Z, re.axis[2]); //up/down
 
-    	VectorMA(boltOrg, 0, re.axis[1], boltOrg);
-    	VectorMA(boltOrg, 0, re.axis[1], boltOrg);
     	VectorMA(boltOrg, -2, re.axis[2], boltOrg);
 
 		//rotational transitions
@@ -10252,8 +10250,6 @@ static void CG_DrawCosmeticOnPlayer2(centity_t* cent, int time, qhandle_t* gameM
 		BG_GiveMeVectorFromMatrix(&matrix, POSITIVE_Y, re.axis[1]); //right
 		BG_GiveMeVectorFromMatrix(&matrix, POSITIVE_Z, re.axis[2]); //up/down
 
-		VectorMA(boltOrg, 0, re.axis[1], boltOrg);
-		VectorMA(boltOrg, 0, re.axis[1], boltOrg);
 		VectorMA(boltOrg, -2, re.axis[2], boltOrg);
 
 		boltOrg[0] += cosmetic->xOffset;

--- a/codemp/game/bg_cosmetics.c
+++ b/codemp/game/bg_cosmetics.c
@@ -1,0 +1,343 @@
+// bg_cosmetics.c
+// cgame and ui, NOT game.
+//
+
+#include "qcommon/q_shared.h"
+#include "bg_public.h"
+#include "bg_cosmetics.h"
+#include "cJSON.h"
+
+#include <ctype.h>
+
+#ifdef _CGAME
+	#include "cgame/cg_local.h"
+#elif UI_BUILD
+	#include "ui/ui_local.h"
+#endif
+
+#define VALID_COSMETIC_OFFSETS(x, y, z) (cJSON_IsNumber(x) && cJSON_IsNumber(y) && cJSON_IsNumber(z))
+
+static void BG_LoadCosmeticCategory(const char *path, int pathLen, int *totalCosmetics, cosmeticItem_t **storePtr)
+{
+	int fileCnt, i, j, fileLen;
+	char cosmeticFiles[MAX_QPATH * 256]; //lets support 256 cosmetics for every category for now.
+	char cosmetic[MAX_QPATH];
+	cosmeticItem_t *cosmeticsPtr;
+	char *ptr;
+
+	fileCnt = trap->FS_GetFileList(path, ".md3", cosmeticFiles, sizeof(cosmeticFiles));
+
+	if (!fileCnt) return;
+
+	cosmeticsPtr = malloc(fileCnt * sizeof(*cosmeticsPtr));
+	if (!cosmeticsPtr) trap->Error(ERR_DROP, S_COLOR_RED"ERROR: Failed to allocate memory for cosmetics.\n");
+
+	ptr = cosmeticFiles;
+	j = 0;
+
+	for (i = 0; i < fileCnt; i++, ptr += fileLen + 1)
+	{
+		qhandle_t handle;
+
+		memset(cosmetic, 0, MAX_QPATH);
+		fileLen = strlen(ptr);
+
+		if ((pathLen + fileLen) > (MAX_QPATH - 1))
+		{
+			Com_Printf(S_COLOR_YELLOW"WARNING: Cosmetic [%s] path exceeded max length of %d, skipping...\n", ptr, MAX_QPATH - 1);
+			continue;
+		}
+
+		Q_strncpyz(cosmetic, ptr, sizeof(cosmetic));
+		COM_StripExtension(cosmetic, cosmetic, sizeof(cosmetic));
+
+		if (strlen(cosmetic) > (MAX_COSMETIC_LENGTH - 1))
+		{
+			Com_Printf(S_COLOR_YELLOW"WARNING: Cosmetic [%s] filename exceeded max length of %d, skipping...\n", cosmetic, MAX_COSMETIC_LENGTH - 1);
+			continue;
+		}
+
+		if (isdigit(cosmetic[0]))
+		{
+			Com_Printf(S_COLOR_YELLOW"WARNING: Cosmetic [%s] filename starts with a digit, skipping...\n", cosmetic);
+			continue;
+		}
+
+		handle = trap->R_RegisterModel(va("%s%s.md3", path, cosmetic));
+
+		if (!handle)
+		{
+			Com_Printf(S_COLOR_YELLOW"WARNING: Failed to register cosmetic [%s], skipping...\n", cosmetic);
+			continue;
+		}
+
+		Q_strncpyz(cosmeticsPtr[j].name, cosmetic, sizeof(cosmeticsPtr[j].name));
+		cosmeticsPtr[j].xOffset = cosmeticsPtr[j].yOffset = cosmeticsPtr[j].zOffset = 0;
+		cosmeticsPtr[j].handle = handle;
+		j++;
+	}
+
+	if (j == 0)
+	{
+		free(cosmeticsPtr);
+		cosmeticsPtr = NULL;
+	}
+	else if (j < fileCnt)
+	{
+		cosmeticItem_t *temp = realloc(cosmeticsPtr, j * sizeof(*cosmeticsPtr));
+		if (!temp) trap->Error(ERR_DROP, S_COLOR_RED"ERROR: Failed to reallocate memory for cosmetics.\n");
+		cosmeticsPtr = temp;
+	}
+
+	*storePtr = cosmeticsPtr;
+	*totalCosmetics = j;
+}
+
+void BG_LoadCosmetics(cosmetics_t *cosmetics)
+{
+	if (!cosmetics) return;
+
+	BG_LoadCosmeticCategory(COSMETIC_HATS_PATH, COSMETIC_HATS_PATH_LENGTH, &cosmetics->totalHats, &cosmetics->hats);
+	BG_LoadCosmeticCategory(COSMETIC_CAPES_PATH, COSMETIC_CAPES_PATH_LENGTH, &cosmetics->totalCapes, &cosmetics->capes);
+}
+
+void BG_FreeCosmetics(cosmetics_t *cosmetics)
+{
+	if (!cosmetics) return;
+
+	if (cosmetics->hats) {
+		free(cosmetics->hats);
+		cosmetics->hats = NULL;
+	}
+
+	if (cosmetics->capes) {
+		free(cosmetics->capes);
+		cosmetics->capes = NULL;
+	}
+
+	cosmetics->totalHats = 0;
+	cosmetics->totalCapes = 0;
+}
+
+void BG_LoadCustomCosmeticOffsets(const char *settingsPath, int pathLen, cosmeticItem_t *cosmetic, const char *model, const char *skin)
+{
+	char fullPath[MAX_QPATH];
+	char *cosmeticName;
+	fileHandle_t file;
+	int fileSize, i;
+	qboolean modelFallback = qfalse; //Let's set the default value to false.
+
+	if (!cosmetic || !cosmetic->handle) return;
+
+	cosmeticName = cosmetic->name;
+
+	if (pathLen + strlen(cosmeticName) + strlen("cosmetic") + 1 >= MAX_QPATH)
+	{
+		Com_Printf(S_COLOR_YELLOW"WARNING: Skipping custom offsets for cosmetic (%s), path too long.\n", cosmeticName);
+		return;
+	}
+
+	Com_sprintf(fullPath, sizeof(fullPath),"%s%s.cosmetic", settingsPath, cosmeticName);
+	fileSize = trap->FS_Open(fullPath, &file, FS_READ);
+
+	if (fileSize <= 0) //File doesn't exist.
+	{
+		cosmetic->xOffset = cosmetic->yOffset = cosmetic->zOffset = 0;
+		trap->FS_Close(file);
+		return;
+	}
+	else
+	{
+		char *buff = malloc((fileSize + 1) * sizeof(char));
+		cJSON *json;
+		cJSON *jsonModel;
+		cJSON *jsonSkin;
+		cJSON *jsonModelFallback;
+		cJSON *xOffset, *yOffset, *zOffset;
+
+		if (!buff)
+		{
+			trap->FS_Close(file);
+			trap->Error(ERR_DROP,S_COLOR_RED"ERROR: Failed to allocate memory of cosmetic offsets.\n");
+		}
+
+		trap->FS_Read(buff, fileSize, file);
+		buff[fileSize] = '\0';
+		trap->FS_Close(file);
+
+		json = cJSON_Parse(buff);
+
+		if (!json)
+		{
+			Com_Printf(S_COLOR_YELLOW"WARNING: Skipping custom offsets for cosmetic (%s), failed to parse JSON.\n", cosmeticName);
+			cosmetic->xOffset = cosmetic->yOffset = cosmetic->zOffset = 0;
+			free(buff);
+			return;
+		}
+
+		jsonModel = cJSON_GetObjectItemCaseSensitive(json, va("%s",model));
+
+		if (!jsonModel) // No custom offsets for the exact model have been been found, lets look for wildcard names.
+		{
+			char* ptr;
+			int longestLen = 0;
+			int skinLen = strlen(model);
+			int len;
+			int index = -1;
+
+			for (i = 0; i < cJSON_GetArraySize(json); i++)
+			{
+				cJSON* temp = cJSON_GetArrayItem(json, i);
+
+				if (!cJSON_IsObject(temp)) continue;
+				ptr = strchr(temp->string, '*');
+				if (!ptr) continue;
+				len = ptr - temp->string;
+
+				if (len <= skinLen && !strncmp(temp->string, model, len))
+				{
+					if (len > longestLen)
+					{
+						longestLen = len;
+						index = i;
+					}
+				}
+			}
+
+			if (index > -1) //We found a wildcard model.
+			{
+				jsonModel = cJSON_GetArrayItem(json, index);
+				goto foundValidModel;
+			}
+			else
+			{
+				cosmetic->xOffset = cosmetic->yOffset = cosmetic->zOffset = 0;
+				cJSON_Delete(json);
+				free(buff);
+				return;
+			}
+		}
+		else
+		{
+			foundValidModel:
+			jsonModelFallback = cJSON_GetObjectItem(jsonModel, "modelFallback");
+			if (cJSON_IsBool(jsonModelFallback))
+			{
+				if (cJSON_IsTrue(jsonModelFallback)) {
+					modelFallback = qtrue;
+				}
+				else
+				{
+					modelFallback = qfalse;
+				}
+			}
+
+			jsonSkin = cJSON_GetObjectItemCaseSensitive(jsonModel, va("%s", skin));
+
+			if (!jsonSkin) // No custom offsets for the exact skin have been been found, lets look for wildcard names.
+			{
+				char *ptr;
+				int longestLen = 0;
+				int skinLen = strlen(skin);
+				int len;
+				int index = -1;
+
+				for (i = 0; i < cJSON_GetArraySize(jsonModel); i++)
+				{
+					cJSON *temp = cJSON_GetArrayItem(jsonModel, i);
+
+					if (!cJSON_IsObject(temp)) continue;
+					ptr = strchr(temp->string, '*');
+					if (!ptr) continue;
+					len = ptr - temp->string;
+
+					if (len <= skinLen && !strncmp(temp->string, skin, len))
+					{
+						if (len > longestLen)
+						{
+							longestLen = len;
+							index = i;
+						}
+					}
+				}
+
+				if (index > -1) //We found a wildcard skin.
+				{
+					jsonSkin = cJSON_GetArrayItem(jsonModel, index);
+
+					xOffset = cJSON_GetObjectItemCaseSensitive(jsonSkin, "xOffset");
+					yOffset = cJSON_GetObjectItemCaseSensitive(jsonSkin, "yOffset");
+					zOffset = cJSON_GetObjectItemCaseSensitive(jsonSkin, "zOffset");
+
+					if (VALID_COSMETIC_OFFSETS(xOffset, yOffset, zOffset)) {
+						cosmetic->xOffset = xOffset->valueint;
+						cosmetic->yOffset = yOffset->valueint;
+						cosmetic->zOffset = zOffset->valueint;
+					}
+					else
+					{
+						Com_Printf(S_COLOR_YELLOW"WARNING: Skipping custom offsets for cosmetic (%s), the skin (%s) JSON object does not contain valid offset values.\n", cosmeticName, jsonSkin->string);
+						cosmetic->xOffset = cosmetic->yOffset = cosmetic->zOffset = 0;
+					}
+				}
+				else //No wildcard found, check if we should fallback to the model's offsets or not.
+				{
+					if (modelFallback)
+					{
+						xOffset = cJSON_GetObjectItemCaseSensitive(jsonModel, "xOffset");
+						yOffset = cJSON_GetObjectItemCaseSensitive(jsonModel, "yOffset");
+						zOffset = cJSON_GetObjectItemCaseSensitive(jsonModel, "zOffset");
+
+						if (VALID_COSMETIC_OFFSETS(xOffset, yOffset, zOffset)) {
+							cosmetic->xOffset = xOffset->valueint;
+							cosmetic->yOffset = yOffset->valueint;
+							cosmetic->zOffset = zOffset->valueint;
+						}
+						else
+						{
+							Com_Printf(S_COLOR_YELLOW"WARNING: Skipping custom offsets for cosmetic (%s), the model (%s) JSON object does not contain valid offset values.\n", cosmeticName, jsonModel->string);
+							cosmetic->xOffset = cosmetic->yOffset = cosmetic->zOffset = 0;
+						}
+					}
+					else
+					{
+						cosmetic->xOffset = cosmetic->yOffset = cosmetic->zOffset = 0;
+					}
+				}
+			}
+			else
+			{
+				xOffset = cJSON_GetObjectItemCaseSensitive(jsonSkin, "xOffset");
+				yOffset = cJSON_GetObjectItemCaseSensitive(jsonSkin, "yOffset");
+				zOffset = cJSON_GetObjectItemCaseSensitive(jsonSkin, "zOffset");
+
+				if (VALID_COSMETIC_OFFSETS(xOffset, yOffset, zOffset)) {
+					cosmetic->xOffset = xOffset->valueint;
+					cosmetic->yOffset = yOffset->valueint;
+					cosmetic->zOffset = zOffset->valueint;
+				}
+				else
+				{
+					Com_Printf(S_COLOR_YELLOW"WARNING: Skipping custom offsets for cosmetic (%s),the skin (%s) JSON object does not contain valid offset values.\n", cosmeticName, jsonSkin->string);
+					cosmetic->xOffset = cosmetic->yOffset = cosmetic->zOffset = 0;
+				}
+			}
+		}
+		cJSON_Delete(json);
+		free(buff);
+	}
+}
+
+cosmeticItem_t *BG_FindCosmeticByName(const char *name, cosmeticItem_t *items, int count)
+{
+	int i;
+
+	if (!name || !*name || !items) return NULL;
+
+	for (i = 0; i < count; i++)
+	{
+		if (!Q_stricmp(items[i].name, name))
+			return &items[i];
+	}
+	return NULL;
+}

--- a/codemp/game/bg_cosmetics.h
+++ b/codemp/game/bg_cosmetics.h
@@ -1,0 +1,37 @@
+#pragma once
+
+#include "qcommon/q_shared.h"
+
+//Let's use 14 bytes because OpenJK and JA++ game modules both use 16 bytes buffer for color1, so if we support up to 16 only, we can pretty much use this on any server.
+//The remaining 2 bytes are to support the actual saber colors, since TaystJK supports up to 12 colors, we need to reserve 2 bytes for the color.
+#define MAX_COSMETIC_LENGTH 14
+
+#define COSMETIC_HATS_PATH "models/cosmetics/hats/"
+#define COSMETIC_HATS_PATH_LENGTH (sizeof(COSMETIC_HATS_PATH) - 1)
+#define COSMETIC_HATS_SETTINGS_PATH "settings/cosmetics/hats/"
+#define COSMETIC_HATS_SETTINGS_PATH_LENGTH (sizeof(COSMETIC_HATS_SETTINGS_PATH) - 1)
+
+#define COSMETIC_CAPES_PATH "models/cosmetics/capes/"
+#define COSMETIC_CAPES_PATH_LENGTH (sizeof(COSMETIC_CAPES_PATH) - 1)
+#define COSMETIC_CAPES_SETTINGS_PATH "settings/cosmetics/capes/"
+#define COSMETIC_CAPES_SETTINGS_PATH_LENGTH (sizeof(COSMETIC_CAPES_SETTINGS_PATH) - 1)
+
+typedef struct cosmeticItem_s {
+	char		name[MAX_COSMETIC_LENGTH];
+	qhandle_t	handle;
+	int			xOffset;
+	int			yOffset;
+	int			zOffset;
+} cosmeticItem_t;
+
+typedef struct cosmetics_s {
+	cosmeticItem_t	*hats;
+	cosmeticItem_t	*capes;
+	int				totalHats;
+	int				totalCapes;
+} cosmetics_t;
+
+void			BG_LoadCosmetics(cosmetics_t *cosmetics);
+void			BG_FreeCosmetics(cosmetics_t *cosmetics);
+void			BG_LoadCustomCosmeticOffsets(const char *settingsPath, int pathLen, cosmeticItem_t *cosmetic,const char *model, const char *skin );
+cosmeticItem_t *BG_FindCosmeticByName(const char *name, cosmeticItem_t *items, int count );

--- a/codemp/ui/CMakeLists.txt
+++ b/codemp/ui/CMakeLists.txt
@@ -33,12 +33,14 @@ endif(WIN32)
 set(MPUIDefines ${MPSharedDefines} "UI_BUILD")
 
 set(MPUIGameFiles
+	"${MPDir}/game/bg_cosmetics.c"
 	"${MPDir}/game/bg_misc.c"
 	"${MPDir}/game/bg_saberLoad.c"
 	"${MPDir}/game/bg_saga.c"
 	"${MPDir}/game/bg_vehicleLoad.c"
 	"${MPDir}/game/bg_weapons.c"
 	"${MPDir}/game/anims.h"
+	"${MPDir}/game/bg_cosmetics.h"
 	"${MPDir}/game/bg_local.h"
 	"${MPDir}/game/bg_public.h"
 	"${MPDir}/game/bg_saga.h"
@@ -93,6 +95,9 @@ set(MPUIRendererFiles
 	)
 source_group("rd-common" FILES ${MPUIRendererFiles})
 set(MPUIFiles ${MPUIFiles} ${MPUIRendererFiles})
+
+list(APPEND MPUIIncludeDirectories ${CJSON_INCLUDE_DIRS})
+list(APPEND MPUILibraries          ${CJSON_LIBRARIES})
 
 add_library(${MPUI} SHARED ${MPUIFiles})
 

--- a/codemp/ui/menudef.h
+++ b/codemp/ui/menudef.h
@@ -132,6 +132,9 @@ along with this program; if not, see <http://www.gnu.org/licenses/>.
 #define FEEDER_SABER_SINGLE_INFO			0x2b			// saber single
 #define FEEDER_SABER_STAFF_INFO				0x2c			// saber staff
 
+#define FEEDER_COSMETIC_HATS				0x2d			// list of locally available hat cosmetics
+#define FEEDER_COSMETIC_CAPES				0x2e			// list of locally available cape cosmetics
+
 
 // Xbox specific, hope no one minds
 #define FEEDER_XBL_ACCOUNTS					0xA0			// list of available XBL accounts

--- a/codemp/ui/ui_local.h
+++ b/codemp/ui/ui_local.h
@@ -154,9 +154,7 @@ typedef struct playerInfo_s {
 #define MAX_SCROLLTEXT_SIZE		4096
 #define MAX_SCROLLTEXT_LINES	64
 
-//Let's use 14 bytes because OpenJK and JA++ game modules both use 16 bytes buffer for color1, so if we support up to 16 only, we can pretty much use this on any server.
-//The remaining 2 bytes are to support the actual saber colors, since TaystJK supports up to 12 colors, we need to reserve 2 bytes for the color.
-#define MAX_COSMETIC_LENGTH 14 
+#include "game/bg_cosmetics.h"
 
 typedef struct aliasInfo_s {
 	const char *name;
@@ -404,6 +402,16 @@ qboolean	UI_ConsoleCommand( int realTime );
 void		UI_DrawHandlePic( float x, float y, float w, float h, qhandle_t hShader );
 void		UI_FillRect( float x, float y, float width, float height, const float *color );
 char		*UI_Cvar_VariableString( const char *var_name );
+
+typedef enum {
+	COSMETIC_CATEGORY_HAT,
+	COSMETIC_CATEGORY_CAPE,
+} cosmeticCategory_t;
+
+void	UI_BeginCosmeticPreview( void );
+void	UI_ApplyCosmetics( void );
+void	UI_ToggleCosmetic( cosmeticCategory_t category, int index );
+void	UI_DrawCosmeticsForChar( itemDef_t *item, vec3_t origin, vec3_t angles );
 
 
 //

--- a/codemp/ui/ui_main.c
+++ b/codemp/ui/ui_main.c
@@ -249,6 +249,17 @@ animation_t	uiHumanoidAnimations[MAX_TOTALANIMATIONS]; //humanoid animations are
 bgLoadedAnim_t bgAllAnims[MAX_ANIM_FILES];
 int uiNumAllAnims = 1; //start off at 0, because 0 will always be assigned to humanoid.
 
+typedef struct cosmeticsPreview_s
+{
+	cosmetics_t  cosmetics;
+	int          selectedHatId;
+	int          selectedCapeId;
+	char         model[MAX_QPATH];
+	char         skin[MAX_QPATH];
+} cosmeticsPreview_t;
+
+static cosmeticsPreview_t uiCosmetics = { { NULL, NULL, 0, 0 }, -1, -1, { 0 }, { 0 } };
+
 animation_t *UI_AnimsetAlloc(void)
 {
 	assert (uiNumAllAnims < MAX_ANIM_FILES);
@@ -1125,6 +1136,7 @@ void UI_Shutdown( void ) {
 	trap->LAN_SaveCachedServers();
 	UI_CleanupGhoul2();
 	UI_FreeAllSpecies();
+	BG_FreeCosmetics( &uiCosmetics.cosmetics );
 }
 
 char *defaultMenu = NULL;
@@ -8121,6 +8133,14 @@ static void UI_RunMenuScript(char **args)
 		{
 			UI_UpdateCharacterSkin();
 		}
+		else if (Q_stricmp(name, "beginCosmeticPreview") == 0)
+		{
+			UI_BeginCosmeticPreview();
+		}
+		else if (Q_stricmp(name, "applyCosmetics") == 0)
+		{
+			UI_ApplyCosmetics();
+		}
 		else if (Q_stricmp(name, "setui_dualforcepower") == 0)
 		{
 			int forcePowerDisable = trap->Cvar_VariableValue("g_forcePowerDisable");
@@ -9702,6 +9722,12 @@ static int UI_FeederCount(float feederID)
 		case FEEDER_COLORCHOICES:
 			return uiInfo.playerSpecies[uiInfo.playerSpeciesIndex].ColorCount;
 
+		case FEEDER_COSMETIC_HATS:
+			return uiCosmetics.cosmetics.totalHats;
+
+		case FEEDER_COSMETIC_CAPES:
+			return uiCosmetics.cosmetics.totalCapes;
+
 		case FEEDER_SIEGE_BASE_CLASS:
 			team = (int)trap->Cvar_VariableValue("ui_team");
 			baseClass = (int)trap->Cvar_VariableValue("ui_siege_class");
@@ -9914,6 +9940,18 @@ static const char *UI_FeederItemText(float feederID, int index, int column,
 		//char *saberProperName=0;
 		UI_SaberProperNameForSaber( saberStaffHiltInfo[index], info );
 		return info;
+	}
+	else if (feederID == FEEDER_COSMETIC_HATS)
+	{
+		if (index >= 0 && index < uiCosmetics.cosmetics.totalHats)
+			return uiCosmetics.cosmetics.hats[index].name;
+		return "";
+	}
+	else if (feederID == FEEDER_COSMETIC_CAPES)
+	{
+		if (index >= 0 && index < uiCosmetics.cosmetics.totalCapes)
+			return uiCosmetics.cosmetics.capes[index].name;
+		return "";
 	}
 	else if (feederID == FEEDER_Q3HEADS) {
 		int actual;
@@ -10516,6 +10554,14 @@ qboolean UI_FeederSelection(float feederFloat, int index, itemDef_t *item)
 				trap->Cvar_Set("char_color_blue", "255");
 			}
 		}
+	}
+	else if (feederID == FEEDER_COSMETIC_HATS)
+	{
+		UI_ToggleCosmetic(COSMETIC_CATEGORY_HAT, index);
+	}
+	else if (feederID == FEEDER_COSMETIC_CAPES)
+	{
+		UI_ToggleCosmetic(COSMETIC_CATEGORY_CAPE, index);
 	}
 	else if (feederID == FEEDER_MOVES)
 	{
@@ -11657,6 +11703,344 @@ static qhandle_t UI_RegisterShaderNoMip( const char *name ) {
 	return trap->R_RegisterShaderNoMip( name );
 }
 
+static qboolean UI_CosmeticPreviewActive( void )
+{
+	menuDef_t *m = Menus_FindByName( "ingame_player_cosmetics" );
+	return ( m && (m->window.flags & WINDOW_VISIBLE) ) ? qtrue : qfalse;
+}
+
+static void UI_PreviewRefreshOffsets( cosmeticItem_t *hat, cosmeticItem_t *cape,
+                                      const char *model, const char *skin )
+{
+	if ( !Q_stricmp( uiCosmetics.model, model ) && !Q_stricmp( uiCosmetics.skin, skin ) )
+		return;
+
+	Q_strncpyz( uiCosmetics.model, model, sizeof(uiCosmetics.model) );
+	Q_strncpyz( uiCosmetics.skin,  skin,  sizeof(uiCosmetics.skin) );
+
+	if ( hat )
+		BG_LoadCustomCosmeticOffsets( COSMETIC_HATS_SETTINGS_PATH, COSMETIC_HATS_SETTINGS_PATH_LENGTH,
+		                              hat, model, skin );
+	if ( cape )
+		BG_LoadCustomCosmeticOffsets( COSMETIC_CAPES_SETTINGS_PATH, COSMETIC_CAPES_SETTINGS_PATH_LENGTH,
+		                              cape, model, skin );
+}
+
+static void UI_BoltCosmeticOnItem( itemDef_t *item, cosmeticItem_t *cosmetic,
+                                   const char *boneName, vec3_t origin, vec3_t angles )
+{
+	int newBolt;
+	mdxaBone_t matrix;
+	vec3_t boltOrg;
+	refEntity_t re;
+
+	if ( !cosmetic || !cosmetic->handle || !item->ghoul2 )
+		return;
+
+	newBolt = trap->G2API_AddBolt( item->ghoul2, 0, (char *)boneName );
+	if ( newBolt == -1 )
+		return;
+
+	trap->G2API_GetBoltMatrix( item->ghoul2, 0, newBolt, &matrix, angles, origin,
+	                          uiInfo.uiDC.realTime, NULL, vec3_origin );
+
+	memset( &re, 0, sizeof(re) );
+
+	BG_GiveMeVectorFromMatrix( &matrix, ORIGIN,     boltOrg );
+	BG_GiveMeVectorFromMatrix( &matrix, POSITIVE_X, re.axis[0] );
+	BG_GiveMeVectorFromMatrix( &matrix, POSITIVE_Y, re.axis[1] );
+	BG_GiveMeVectorFromMatrix( &matrix, POSITIVE_Z, re.axis[2] );
+
+	VectorMA( boltOrg, -2, re.axis[2], boltOrg );
+
+	boltOrg[0] += cosmetic->xOffset;
+	boltOrg[1] += cosmetic->yOffset;
+	boltOrg[2] += cosmetic->zOffset;
+
+	re.hModel = cosmetic->handle;
+	VectorCopy( boltOrg, re.origin );
+	VectorCopy( boltOrg, re.lightingOrigin );
+	re.renderfx = RF_LIGHTING_ORIGIN | RF_NOSHADOW | RF_NOLOD;
+
+	trap->R_AddRefEntityToScene( &re );
+}
+
+void UI_DrawCosmeticsForChar( itemDef_t *item, vec3_t origin, vec3_t angles )
+{
+	cosmeticItem_t *hat  = NULL;
+	cosmeticItem_t *cape = NULL;
+	char modelName[MAX_QPATH];
+	char *skinName;
+	char *p;
+
+	if ( !item || !item->ghoul2 ) return;
+
+	if ( UI_CosmeticPreviewActive() )
+	{
+		// Cosmetics menu is open: render the pending selection.
+		if ( uiCosmetics.selectedHatId >= 0 && uiCosmetics.selectedHatId < uiCosmetics.cosmetics.totalHats )
+			hat = &uiCosmetics.cosmetics.hats[uiCosmetics.selectedHatId];
+		if ( uiCosmetics.selectedCapeId >= 0 && uiCosmetics.selectedCapeId < uiCosmetics.cosmetics.totalCapes )
+			cape = &uiCosmetics.cosmetics.capes[uiCosmetics.selectedCapeId];
+
+		Q_strncpyz( modelName, uiCosmetics.model, sizeof(modelName) );
+		skinName = uiCosmetics.skin;
+	}
+	else
+	{
+		char color[MAX_QPATH];
+		char hatName[MAX_COSMETIC_LENGTH];
+		char capeName[MAX_COSMETIC_LENGTH];
+
+		trap->Cvar_VariableStringBuffer( "color1", color, sizeof(color) );
+		Q_StripDigits( color, hatName, sizeof(hatName), REMOVE_DIGITS_INITIAL );
+		if ( hatName[0] )
+			hat = BG_FindCosmeticByName( hatName, uiCosmetics.cosmetics.hats, uiCosmetics.cosmetics.totalHats );
+
+		trap->Cvar_VariableStringBuffer( "color2", color, sizeof(color) );
+		Q_StripDigits( color, capeName, sizeof(capeName), REMOVE_DIGITS_INITIAL );
+		if ( capeName[0] )
+			cape = BG_FindCosmeticByName( capeName, uiCosmetics.cosmetics.capes, uiCosmetics.cosmetics.totalCapes );
+
+		Q_strncpyz( modelName, UI_Cvar_VariableString( "ui_char_model" ), sizeof(modelName) );
+		p = strrchr( modelName, '/' );
+		if ( p )
+		{
+			*p = '\0';
+			skinName = p + 1;
+			p = strchr( skinName, '|' );
+			if ( p ) *p = '\0';
+		}
+		else
+		{
+			skinName = "default";
+		}
+	}
+
+	UI_PreviewRefreshOffsets( hat, cape, modelName, skinName );
+
+	UI_BoltCosmeticOnItem( item, hat,  "*head_top", origin, angles );
+	UI_BoltCosmeticOnItem( item, cape, "*back",     origin, angles );
+}
+
+static int UI_FindEquippedId( const char *cvarName, cosmeticItem_t *items, int count )
+{
+	char color[MAX_QPATH];
+	char name[MAX_COSMETIC_LENGTH];
+	int i;
+
+	trap->Cvar_VariableStringBuffer( cvarName, color, sizeof(color) );
+	Q_StripDigits( color, name, sizeof(name), REMOVE_DIGITS_INITIAL );
+	if ( !name[0] ) return -1;
+
+	for ( i = 0; i < count; i++ )
+	{
+		if ( !Q_stricmp( items[i].name, name ) )
+			return i;
+	}
+	return -1;
+}
+
+static void UI_SetCosmeticListCursor( int feederID, int index )
+{
+	menuDef_t *menu = Menus_FindByName( "ingame_player_cosmetics" );
+	int i;
+
+	if ( !menu ) return;
+
+	for ( i = 0; i < menu->itemCount; i++ )
+	{
+		itemDef_t *item = menu->items[i];
+		if ( item->special == feederID )
+		{
+			listBoxDef_t *listPtr = item->typeData.listbox;
+			item->cursorPos = index;
+			if ( listPtr && index >= 0 ) {
+				listPtr->cursorPos = index;
+			}
+
+			return;
+		}
+	}
+}
+
+static void UI_PreviewApplyCharacter( const char *model, const char *headSkin,
+                                      const char *torsoSkin, const char *legSkin,
+                                      qboolean multipart )
+{
+	menuDef_t *menu = Menus_FindByName( "ingame_player_cosmetics" );
+	itemDef_t *item;
+	char modelPath[MAX_QPATH];
+	char skinPath[MAX_QPATH];
+	int  animLen = 0;
+
+	if ( !menu ) return;
+
+	item = (itemDef_t *)Menu_FindItemByName( menu, "character" );
+	if ( !item ) return;
+
+	ItemParse_model_g2anim_go( item, "BOTH_STAND1" );
+
+	Com_sprintf( modelPath, sizeof(modelPath), "models/players/%s/model.glm", model );
+	ItemParse_asset_model_go( item, modelPath, &animLen );
+
+	if ( multipart )
+	{
+		Com_sprintf( skinPath, sizeof(skinPath), "models/players/%s/|%s|%s|%s",
+		             model, headSkin, torsoSkin, legSkin );
+	}
+	else
+	{
+		Com_sprintf( skinPath, sizeof(skinPath), "models/players/%s/model_%s.skin",
+		             model, headSkin );
+	}
+	ItemParse_model_g2skin_go( item, skinPath );
+}
+
+static void UI_PreviewSyncCharacter( void )
+{
+	char model[MAX_QPATH];
+	char *skinSep;
+	char *pipe;
+
+	trap->Cvar_VariableStringBuffer( "model", model, sizeof(model) );
+
+	pipe = strchr( model, '|' );
+	if ( pipe )
+	{
+		char *p1 = pipe + 1;
+		char *p2 = strchr( p1, '|' );
+		const char *headSkin  = "head_a1";
+		const char *torsoSkin = "torso_a1";
+		const char *legSkin   = "lower_a1";
+
+		*pipe = '\0';
+		skinSep = strrchr( model, '/' );
+		if ( skinSep )
+		{
+			*skinSep = '\0';
+			headSkin = skinSep + 1;
+		}
+
+		if ( p2 )
+		{
+			*p2 = '\0';
+			torsoSkin = p1;
+			legSkin   = p2 + 1;
+		}
+		else if ( p1[0] )
+		{
+			torsoSkin = p1;
+		}
+
+		Q_strncpyz( uiCosmetics.model, model,    sizeof(uiCosmetics.model) );
+		Q_strncpyz( uiCosmetics.skin,  headSkin, sizeof(uiCosmetics.skin) );
+
+		UI_PreviewApplyCharacter( model, headSkin, torsoSkin, legSkin, qtrue );
+	}
+	else
+	{
+		char skinName[MAX_QPATH];
+
+		skinSep = strrchr( model, '/' );
+		if ( skinSep )
+		{
+			Q_strncpyz( skinName, skinSep + 1, sizeof(skinName) );
+			*skinSep = '\0';
+		}
+		else
+		{
+			Q_strncpyz( skinName, "default", sizeof(skinName) );
+		}
+
+		Q_strncpyz( uiCosmetics.model, model,    sizeof(uiCosmetics.model) );
+		Q_strncpyz( uiCosmetics.skin,  skinName, sizeof(uiCosmetics.skin) );
+
+		UI_PreviewApplyCharacter( model, skinName, skinName, skinName, qfalse );
+	}
+}
+
+void UI_BeginCosmeticPreview( void )
+{
+	UI_PreviewSyncCharacter();
+
+	uiCosmetics.selectedHatId  = UI_FindEquippedId( "color1", uiCosmetics.cosmetics.hats,  uiCosmetics.cosmetics.totalHats );
+	uiCosmetics.selectedCapeId = UI_FindEquippedId( "color2", uiCosmetics.cosmetics.capes, uiCosmetics.cosmetics.totalCapes );
+
+	if ( uiCosmetics.selectedHatId >= 0 )
+		BG_LoadCustomCosmeticOffsets( COSMETIC_HATS_SETTINGS_PATH, COSMETIC_HATS_SETTINGS_PATH_LENGTH,
+		                              &uiCosmetics.cosmetics.hats[uiCosmetics.selectedHatId],
+		                              uiCosmetics.model, uiCosmetics.skin );
+	if ( uiCosmetics.selectedCapeId >= 0 )
+		BG_LoadCustomCosmeticOffsets( COSMETIC_CAPES_SETTINGS_PATH, COSMETIC_CAPES_SETTINGS_PATH_LENGTH,
+		                              &uiCosmetics.cosmetics.capes[uiCosmetics.selectedCapeId],
+		                              uiCosmetics.model, uiCosmetics.skin );
+
+	UI_SetCosmeticListCursor( FEEDER_COSMETIC_HATS,  uiCosmetics.selectedHatId );
+	UI_SetCosmeticListCursor( FEEDER_COSMETIC_CAPES, uiCosmetics.selectedCapeId );
+}
+
+void UI_ToggleCosmetic( cosmeticCategory_t category, int index )
+{
+	int *current;
+	int total;
+	int feederID;
+	cosmeticItem_t *items;
+	const char *settingsPath;
+	int settingsPathLen;
+
+	if ( category == COSMETIC_CATEGORY_HAT )
+	{
+		current         = &uiCosmetics.selectedHatId;
+		total           = uiCosmetics.cosmetics.totalHats;
+		feederID        = FEEDER_COSMETIC_HATS;
+		items           = uiCosmetics.cosmetics.hats;
+		settingsPath    = COSMETIC_HATS_SETTINGS_PATH;
+		settingsPathLen = COSMETIC_HATS_SETTINGS_PATH_LENGTH;
+	}
+	else
+	{
+		current         = &uiCosmetics.selectedCapeId;
+		total           = uiCosmetics.cosmetics.totalCapes;
+		feederID        = FEEDER_COSMETIC_CAPES;
+		items           = uiCosmetics.cosmetics.capes;
+		settingsPath    = COSMETIC_CAPES_SETTINGS_PATH;
+		settingsPathLen = COSMETIC_CAPES_SETTINGS_PATH_LENGTH;
+	}
+
+	if ( index < 0 || index >= total )
+		return;
+
+	*current = (*current == index) ? -1 : index;
+
+	if ( *current >= 0 )
+		BG_LoadCustomCosmeticOffsets( settingsPath, settingsPathLen,
+		                              &items[*current],
+		                              uiCosmetics.model, uiCosmetics.skin );
+
+	UI_SetCosmeticListCursor( feederID, *current );
+}
+
+void UI_ApplyCosmetics( void )
+{
+	char color[MAX_QPATH];
+	int colorVal;
+
+	trap->Cvar_VariableStringBuffer( "color1", color, sizeof(color) );
+	colorVal = atoi( color );
+	if ( uiCosmetics.selectedHatId >= 0 && uiCosmetics.selectedHatId < uiCosmetics.cosmetics.totalHats )
+		trap->Cvar_Set( "color1", va( "%d%s", colorVal, uiCosmetics.cosmetics.hats[uiCosmetics.selectedHatId].name ) );
+	else
+		trap->Cvar_Set( "color1", va( "%d", colorVal ) );
+
+	trap->Cvar_VariableStringBuffer( "color2", color, sizeof(color) );
+	colorVal = atoi( color );
+	if ( uiCosmetics.selectedCapeId >= 0 && uiCosmetics.selectedCapeId < uiCosmetics.cosmetics.totalCapes )
+		trap->Cvar_Set( "color2", va( "%d%s", colorVal, uiCosmetics.cosmetics.capes[uiCosmetics.selectedCapeId].name ) );
+	else
+		trap->Cvar_Set( "color2", va( "%d", colorVal ) );
+}
+
 /*
 =================
 UI_Init
@@ -11769,6 +12153,8 @@ void UI_Init( qboolean inGameLoad ) {
 
 	UI_BuildPlayerModel_List(inGameLoad);
 	UI_BuildQ3Model_List();
+
+	BG_LoadCosmetics( &uiCosmetics.cosmetics );
 
 	uiInfo.uiDC.cursor	= trap->R_RegisterShaderNoMip( "menu/art/3_cursor2" );
 	uiInfo.uiDC.whiteShader = trap->R_RegisterShaderNoMip( "white" );

--- a/codemp/ui/ui_main.c
+++ b/codemp/ui/ui_main.c
@@ -11737,7 +11737,7 @@ static void UI_BoltCosmeticOnItem( itemDef_t *item, cosmeticItem_t *cosmetic,
 	if ( !cosmetic || !cosmetic->handle || !item->ghoul2 )
 		return;
 
-	newBolt = trap->G2API_AddBolt( item->ghoul2, 0, (char *)boneName );
+	newBolt = trap->G2API_AddBolt( item->ghoul2, 0, boneName );
 	if ( newBolt == -1 )
 		return;
 
@@ -11875,8 +11875,6 @@ static void UI_PreviewApplyCharacter( const char *model, const char *headSkin,
 
 	item = (itemDef_t *)Menu_FindItemByName( menu, "character" );
 	if ( !item ) return;
-
-	ItemParse_model_g2anim_go( item, "BOTH_STAND1" );
 
 	Com_sprintf( modelPath, sizeof(modelPath), "models/players/%s/model.glm", model );
 	ItemParse_asset_model_go( item, modelPath, &animLen );

--- a/codemp/ui/ui_main.c
+++ b/codemp/ui/ui_main.c
@@ -11769,28 +11769,25 @@ void UI_DrawCosmeticsForChar( itemDef_t *item, vec3_t origin, vec3_t angles )
 {
 	cosmeticItem_t *hat  = NULL;
 	cosmeticItem_t *cape = NULL;
-	char modelName[MAX_QPATH];
-	char *skinName;
-	char *p;
 
 	if ( !item || !item->ghoul2 ) return;
 
 	if ( UI_CosmeticPreviewActive() )
 	{
-		// Cosmetics menu is open: render the pending selection.
+		// Cosmetics menu is open: render the pending selection. 
 		if ( uiCosmetics.selectedHatId >= 0 && uiCosmetics.selectedHatId < uiCosmetics.cosmetics.totalHats )
 			hat = &uiCosmetics.cosmetics.hats[uiCosmetics.selectedHatId];
 		if ( uiCosmetics.selectedCapeId >= 0 && uiCosmetics.selectedCapeId < uiCosmetics.cosmetics.totalCapes )
 			cape = &uiCosmetics.cosmetics.capes[uiCosmetics.selectedCapeId];
-
-		Q_strncpyz( modelName, uiCosmetics.model, sizeof(modelName) );
-		skinName = uiCosmetics.skin;
 	}
 	else
 	{
 		char color[MAX_QPATH];
 		char hatName[MAX_COSMETIC_LENGTH];
 		char capeName[MAX_COSMETIC_LENGTH];
+		char modelName[MAX_QPATH];
+		char *skinName;
+		char *p;
 
 		trap->Cvar_VariableStringBuffer( "color1", color, sizeof(color) );
 		Q_StripDigits( color, hatName, sizeof(hatName), REMOVE_DIGITS_INITIAL );
@@ -11815,9 +11812,9 @@ void UI_DrawCosmeticsForChar( itemDef_t *item, vec3_t origin, vec3_t angles )
 		{
 			skinName = "default";
 		}
-	}
 
-	UI_PreviewRefreshOffsets( hat, cape, modelName, skinName );
+		UI_PreviewRefreshOffsets( hat, cape, modelName, skinName );
+	}
 
 	UI_BoltCosmeticOnItem( item, hat,  "*head_top", origin, angles );
 	UI_BoltCosmeticOnItem( item, cape, "*back",     origin, angles );

--- a/codemp/ui/ui_shared.c
+++ b/codemp/ui/ui_shared.c
@@ -5585,6 +5585,8 @@ void Item_Model_Paint(itemDef_t *item)
 			ent.shaderRGBA[2] = ui_char_color_blue.integer;
 			ent.shaderRGBA[3] = 255;
 //			UI_TalkingHead(item);
+
+			UI_DrawCosmeticsForChar( item, origin, angles );
 		}
 		if ( item->flags&ITF_ISANYSABER )
 		{//UGH, draw the saber blade!


### PR DESCRIPTION
This PR adds  cosmetics preview to the UI.

accesible in game by going to: Profile -> Custom -> Cosmetics

<img width="2806" height="2009" alt="afbeelding" src="https://github.com/user-attachments/assets/fa33235d-54fd-4c4c-a399-f4dd3db421cb" />


<img width="3840" height="2029" alt="afbeelding" src="https://github.com/user-attachments/assets/53a88bc3-dc73-41a8-a9e5-f2d55690bc13" />

<img width="3767" height="2071" alt="afbeelding" src="https://github.com/user-attachments/assets/5e726dde-8b0e-4b99-aac7-e62cded5006c" />

the PR also includes a bunch of  fixes/improvemnts related to cosmetics in the cgame module:

- Instead of having a pointer to our local cosmetics array in the userinfo, we now keep a copy so cosmetic custom offsets are applied properly.
- missing off by one check when validating cosmetics
- fix format string mismatch when loading cosmetics
