### PR TITLE
Allow repositioning cg_drawScore text

### DIFF
--- a/codemp/cgame/cg_draw.c
+++ b/codemp/cgame/cg_draw.c
@@ -2217,8 +2217,8 @@ void CG_DrawHUD(centity_t	*cent)
 							{
 								if (cg_drawScore.integer > 1 && cgs.gametype >= GT_TEAM && cgs.gametype != GT_SIEGE) {
 									CG_DrawScaledProportionalString(
-											SCREEN_WIDTH - (SCREEN_WIDTH - focusItem->window.rect.x) * cgs.widthRatioCoef,
-											focusItem->window.rect.y - 14,
+											SCREEN_WIDTH - (SCREEN_WIDTH - focusItem->window.rect.x - cg_drawScoreX.value) * cgs.widthRatioCoef,
+											focusItem->window.rect.y - cg_drawScoreY.value - 14,
 											scoreStr,
 											UI_RIGHT | UI_DROPSHADOW,
 											focusItem->window.foreColor,
@@ -2226,8 +2226,8 @@ void CG_DrawHUD(centity_t	*cent)
 								}
 								else {
 									CG_DrawScaledProportionalString(
-											SCREEN_WIDTH - (SCREEN_WIDTH - focusItem->window.rect.x) * cgs.widthRatioCoef,
-											focusItem->window.rect.y,
+											SCREEN_WIDTH - (SCREEN_WIDTH - focusItem->window.rect.x - cg_drawScoreX.value) * cgs.widthRatioCoef,
+											focusItem->window.rect.y - cg_drawScoreY.value,
 											scoreStr,
 											UI_RIGHT|UI_DROPSHADOW,
 											focusItem->window.foreColor,

--- a/codemp/cgame/cg_xcvar.h
+++ b/codemp/cgame/cg_xcvar.h
@@ -78,6 +78,8 @@ XCVAR_DEF( cg_chatBoxShowCutoff,	"0",	NULL,					CVAR_ARCHIVE_ND )
 XCVAR_DEF( cg_hudColors,			"0",	NULL,					CVAR_ARCHIVE )
 XCVAR_DEF( cg_tintHud,				"1",	NULL,					CVAR_ARCHIVE )
 XCVAR_DEF( cg_drawScore,			"2",	NULL,					CVAR_ARCHIVE ) //score counter on HUD
+XCVAR_DEF( cg_drawScoreX,			"0",	NULL,					CVAR_ARCHIVE ) //horizontal offset for score counter on HUD
+XCVAR_DEF( cg_drawScoreY,			"0",	NULL,					CVAR_ARCHIVE ) //vertical offset for score counter on HUD
 XCVAR_DEF( cg_drawScores,			"1",	NULL,					CVAR_ARCHIVE ) //team score counter in top right
 XCVAR_DEF( cg_drawVote,				"1",	NULL,					CVAR_ARCHIVE )
 XCVAR_DEF( cg_showpos,				"0",	NULL,					CVAR_NONE )

--- a/codemp/game/bg_public.h
+++ b/codemp/game/bg_public.h
@@ -554,7 +554,6 @@ extern int bgForcePowerCost[NUM_FORCE_POWERS][NUM_FORCE_POWER_LEVELS];
 #define TAYSTJK_INFO_FIXROLL_1	            (1<<4) // enable rolling while using force grip (1.0.0)
 #define TAYSTJK_INFO_FIXROLL_2	            (1<<5) // enable rolling while using force grip + chaining rolls
 #define TAYSTJK_INFO_FIXROLL_3	            (1<<6) // jk2 roll
-#define TAYSTJK_INFO_HEADSLIDE				(1<<7)
 
 #define _SPPHYSICS 1
 #define _COOP 1

--- a/codemp/ui/ui_xdocs.h
+++ b/codemp/ui/ui_xdocs.h
@@ -248,6 +248,12 @@ XDOCS_CVAR_DEF("cg_drawScore", "Displays your score in the lower right",
 	SETTING("2", "Score, team score, and bias is drawn")
 )
 
+XDOCS_CVAR_DEF("cg_drawScoreX", "Offset cg_drawScore horizontally", ""
+)
+
+XDOCS_CVAR_DEF("cg_drawScoreY", "Offset cg_drawScore vertically", ""
+)
+
 XDOCS_CVAR_DEF("cg_drawScores", "Displays the team scores",
 "This does not apply to the simple HUD." NL
 	SETTING("0", "Scores are hidden") NL


### PR DESCRIPTION
Closes #306 

`cg_drawScoreX` and `cg_drawScoreY` now offset the position of `cg_drawScore`. Might need to set negative values for desired effect.