### PR TITLE
Fix Assets target dependency being Windows-only in game and ui

### DIFF
--- a/codemp/cgame/CMakeLists.txt
+++ b/codemp/cgame/CMakeLists.txt
@@ -186,9 +186,10 @@ set_target_properties(${MPCGame} PROPERTIES PROJECT_LABEL "MP Client Game Librar
 # no libraries used
 if(MPCGameLibraries)
 	target_link_libraries(${MPCGame} ${MPCGameLibraries})
-	
-	if (GIT_FOUND)
-		add_dependencies(${MPCGame} GET_GIT_TAG_AND_HASH)
-	endif()
-	add_dependencies(${MPCGame} Assets)
 endif(MPCGameLibraries)
+
+if (GIT_FOUND)
+	add_dependencies(${MPCGame} GET_GIT_TAG_AND_HASH)
+endif(GIT_FOUND)
+
+add_dependencies(${MPCGame} Assets)

--- a/codemp/game/CMakeLists.txt
+++ b/codemp/game/CMakeLists.txt
@@ -245,9 +245,10 @@ set_target_properties(${MPGame} PROPERTIES PROJECT_LABEL "MP Game Library")
 # no libraries used
 if(MPGameLibraries)
 	target_link_libraries(${MPGame} ${MPGameLibraries})
-
-	if (GIT_FOUND)
-		add_dependencies(${MPGame} GET_GIT_TAG_AND_HASH)
-	endif()
-	add_dependencies(${MPGame} Assets)
 endif(MPGameLibraries)
+
+if (GIT_FOUND)
+	add_dependencies(${MPGame} GET_GIT_TAG_AND_HASH)
+endif(GIT_FOUND)
+
+add_dependencies(${MPGame} Assets)

--- a/codemp/ui/CMakeLists.txt
+++ b/codemp/ui/CMakeLists.txt
@@ -128,9 +128,10 @@ set_target_properties(${MPUI} PROPERTIES PROJECT_LABEL "MP UI Library")
 # no libraries used
 if(MPUILibraries)
 	target_link_libraries(${MPUI} ${MPUILibraries})
-	
-	if (GIT_FOUND)
-		add_dependencies(${MPUI} GET_GIT_TAG_AND_HASH)
-	endif()
-	add_dependencies(${MPUI} Assets)
 endif(MPUILibraries)
+
+if (GIT_FOUND)
+	add_dependencies(${MPUI} GET_GIT_TAG_AND_HASH)
+endif(GIT_FOUND)
+
+add_dependencies(${MPUI} Assets)


### PR DESCRIPTION
The add_dependencies calls for Assets and GET_GIT_TAG_AND_HASH were nested inside if(MPGameLibraries/MPUILibraries) blocks which only evaluated true on Windows, causing the assets pk3 to not build on Linux/macOS clean builds. cgame already worked via an unconditional CJSON_LIBRARIES append making MPCGameLibraries non-empty, but is fixed here for consistency. Found this when trying to upload server/game build to docker container registry, hopefully this fixes the failed build/upload.