### PR TITLE
[filesystem] Default fs_basegame to fs_forcegame when set

### DIFF
--- a/codemp/qcommon/files.cpp
+++ b/codemp/qcommon/files.cpp
@@ -3910,10 +3910,15 @@ void FS_Startup( const char *gameName ) {
 	fs_cdpath = Cvar_Get ("fs_cdpath", "", CVAR_INIT|CVAR_PROTECTED, "(Read Only) Location for development files" );
 	fs_basepath = Cvar_Get ("fs_basepath", Sys_DefaultInstallPath(), CVAR_INIT|CVAR_PROTECTED, "(Read Only) Location for game files" );
 #ifdef DEDICATED
-	fs_basegame = Cvar_Get ("fs_basegame", "", CVAR_INIT );
+	fs_forcegame = Cvar_Get ("fs_forcegame", "", CVAR_INIT, "Folder to use for overriding of fs_game (can not be set by the server)." );
 #else
-	fs_basegame = Cvar_Get ("fs_basegame", TAYSTJKGAME, CVAR_INIT );
+	fs_forcegame = Cvar_Get("fs_forcegame", TAYSTJKGAME, CVAR_INIT, "Folder to use for overriding of fs_game (can not be set by the server).");
 #endif
+
+	const char *baseGame = fs_forcegame->string[0] ? fs_forcegame->string : "";
+	fs_basegame = Cvar_Get ("fs_basegame", baseGame, CVAR_INIT );
+	Cvar_Set("fs_basegame", baseGame);
+
 	fs_portable = Cvar_Get ("fs_portable", "1", CVAR_INIT|CVAR_PROTECTED, "Disable fs_homepath and use only one folder for all game files" );
 	homePath = Sys_DefaultHomePath();
 	if (!homePath || !homePath[0]) {
@@ -3925,11 +3930,6 @@ void FS_Startup( const char *gameName ) {
 
 	fs_dirbeforepak = Cvar_Get("fs_dirbeforepak", "0", CVAR_INIT|CVAR_PROTECTED, "Prioritize directories before paks if not pure" );
 
-#ifdef DEDICATED
-	fs_forcegame = Cvar_Get ("fs_forcegame", "", CVAR_INIT, "Folder to use for overriding of fs_game (can not be set by the server)." );
-#else
-	fs_forcegame = Cvar_Get("fs_forcegame", TAYSTJKGAME, CVAR_INIT, "Folder to use for overriding of fs_game (can not be set by the server).");
-#endif
 	// add search path elements in reverse priority order (lowest priority first)
 	if (fs_cdpath->string[0]) {
 		FS_AddGameDirectory( fs_cdpath->string, gameName );


### PR DESCRIPTION
Use fs_forcegame as fs_basegame's default when available, otherwise keep the basejka default of an empty fs_basegame. Manual fs_basegame values still take precedence. Previously, fs_baseGame always just defaulted to "taystjk"