### PR TITLE
Make cg_strafeHelper copy show/hide/fade conditions of hud and fix cg_showpos crashes

### DIFF
--- a/codemp/cgame/cg_draw.c
+++ b/codemp/cgame/cg_draw.c
@@ -11433,8 +11433,8 @@ static void CG_Draw2D( void ) {
 	if (!cl_paused.integer) {
 		CG_DrawBracketedEntities();
 		CG_DrawUpperRight();
-		DF_DrawShowPos();
-	}
+}
+DF_DrawShowPos();
 
 	if ( !CG_DrawFollow() ) {
 		CG_DrawWarmup();

--- a/codemp/cgame/hud_strafehelper.c
+++ b/codemp/cgame/hud_strafehelper.c
@@ -28,6 +28,13 @@ along with this program; if not, see <https://www.gnu.org/licenses/>.
 #include "hud_strafehelper.h"
 #include "cg_local.h"
 
+// function that stores whether it's safe to display cg_showpos
+static qboolean posSafe = qfalse;
+
+// vehicle functions for cg_pitchHelper hide states
+qboolean CG_InFighter( void );
+qboolean CG_InATST( void );
+
 int DF_GetMovePhysics() {
 	int physics = MV_JKA;
 
@@ -686,6 +693,7 @@ int DF_SetPlayerState(centity_t* cent)
 		DF_SetClientCmd(cent);
 	}
 	else {
+		posSafe = qfalse;
 		return 0;
 	}
 
@@ -708,6 +716,7 @@ int DF_SetPlayerState(centity_t* cent)
 	state.onSlick = DF_IsSlickSurf();
 	DF_SetPhysics();
 	DF_SetCGAZ();
+	posSafe = qtrue;
 	return 1;
 }
 
@@ -2441,7 +2450,10 @@ void DF_RaceTimer(void)
 
 void DF_DrawShowPos(void)
 {
-	static char showPosString[128];
+    if (!posSafe)
+        return;
+	
+    static char showPosString[128];
 	static char showPitchString[8];
 	vec4_t colorPitch = { 0, 0, 0, 1 };
 	float pitchAngle = fabsf(state.viewAngles[PITCH] + cg_pitchHelperOffset.value);
@@ -2460,15 +2472,52 @@ void DF_DrawShowPos(void)
 		colorPitch[1] = 0;
 	}
 
-	if (cg_pitchHelper.value) {
-		Com_sprintf(showPitchString, sizeof(showPitchString), "%.1f", (float)state.viewAngles[PITCH]);
-		CG_Text_Paint((float)cg_pitchHelperX.integer, (float)cg_pitchHelperY.integer, 1.0f, colorPitch, showPitchString, 0, 0, ITEM_TEXTSTYLE_OUTLINESHADOWED, FONT_SMALL2);
-	}
+	// cg_pitchHelper with all hide/fade logic
+    if (cg_pitchHelper.value) {
+        qboolean inFighterOrWalker = (qboolean)(
+            cg.predictedPlayerState.m_iVehicleNum &&
+            (CG_InFighter() || CG_InATST()));
 
-	if (!cg_showpos.integer)
-		return;
+        qboolean intermissionOrSpec = (qboolean)(
+            cg.predictedPlayerState.pm_type == PM_INTERMISSION ||
+            cg.predictedPlayerState.pm_type == PM_SPECTATOR);
 
-	const float vel = sqrtf(state.cgaz.v * state.cgaz.v + state.velocity[2] * state.velocity[2]);
+        // base hide conditions
+        qboolean shouldDraw = (qboolean)(
+            cg_drawHud.integer &&
+            !intermissionOrSpec &&
+            cg.snap->ps.stats[STAT_HEALTH] > 0 &&
+            !cg.showScores &&
+            !inFighterOrWalker);
+
+        if (shouldDraw) {
+            float alpha = 1.0f;
+            if (cg.snap->ps.fallingToDeath) {
+                float fallTime = (float)(cg.time - cg.snap->ps.fallingToDeath);
+                fallTime /= (FALL_FADE_TIME / 2);
+                if (fallTime < 0.0f) fallTime = 0.0f;
+                if (fallTime > 1.0f) fallTime = 1.0f;
+                alpha = 1.0f - fallTime;
+            }
+
+            if (alpha > 0.0f) {
+                colorPitch[3] = alpha;
+                Com_sprintf(showPitchString, sizeof(showPitchString),
+                            "%.1f", (float)state.viewAngles[PITCH]);
+                CG_Text_Paint((float)cg_pitchHelperX.integer,
+                              (float)cg_pitchHelperY.integer,
+                              1.0f, colorPitch, showPitchString,
+                              0, 0, ITEM_TEXTSTYLE_OUTLINESHADOWED, FONT_SMALL2);
+            }
+        }
+    }
+
+    // cg_showpos with all hide logic
+    if (!cg_showpos.integer ||
+	   cl_paused.integer)
+        return;
+
+    const float vel = sqrtf(state.cgaz.v * state.cgaz.v + state.velocity[2] * state.velocity[2]);
 
 	Com_sprintf(showPosString, sizeof(showPosString), "pos:   %.2f   %.2f   %.2f\nang:   %.2f   %.2f\nvel:     %.2f",
 		(float)state.viewOrg[0], (float)state.viewOrg[1], (float)state.viewOrg[2], (float)state.viewAngles[PITCH], (float)state.viewAngles[YAW], vel);


### PR DESCRIPTION
These changes make the cg_strafeHelper display automatically show, hide, and fade out at the same times that the hud items at the bottom of the screen do. These changes also fix a bug that will crash the game when you turn on the cg_showpos display in certain cases. One case is if you try to turn cg_showpos on after you load a map during the time that you're still in spectator mode before clicking join game. The other case is if cg_showpos is already turned on and you load a map from the main menu, from spectator mode, or that same case when you're in spectator mode after a map has loaded before you click join game.