### PR TITLE
Fix NPCs reusing slots with stale values

### DIFF
--- a/codemp/cgame/cg_players.c
+++ b/codemp/cgame/cg_players.c
@@ -3962,6 +3962,37 @@ static void CG_ClearLerpFrame( centity_t *cent, clientInfo_t *ci, lerpFrame_t *l
 	}
 }
 
+static void CG_UpdateNPCBoneAvailability( centity_t *cent ) {
+	if ( cent->currentState.eType != ET_NPC )
+	{
+		return;
+	}
+
+	if ( cent->currentState.NPC_class == CLASS_VEHICLE )
+	{
+		cent->noLumbar = qtrue;
+		cent->noFace = qtrue;
+		return;
+	}
+
+	cent->noLumbar = qfalse;
+	cent->noFace = qfalse;
+
+	if ( !cent->ghoul2 )
+	{
+		return;
+	}
+
+	if ( trap->G2API_AddBolt( cent->ghoul2, 0, "lower_lumbar" ) == -1 )
+	{
+		cent->noLumbar = qtrue;
+	}
+
+	if ( trap->G2API_AddBolt( cent->ghoul2, 0, "face" ) == -1 )
+	{
+		cent->noFace = qtrue;
+	}
+}
 
 /*
 ===============
@@ -8921,24 +8952,7 @@ void CG_G2AnimEntModelLoad(centity_t *cent)
 				trap->G2API_AddBolt(cent->ghoul2, 0, "Motion");
 			}
 
-			// If this is a not vehicle...
-			if ( cent->currentState.NPC_class != CLASS_VEHICLE )
-			{
-				if (trap->G2API_AddBolt(cent->ghoul2, 0, "lower_lumbar") == -1)
-				{ //check now to see if we have this bone for setting anims and such
-					cent->noLumbar = qtrue;
-				}
-
-				if (trap->G2API_AddBolt(cent->ghoul2, 0, "face") == -1)
-				{ //check now to see if we have this bone for setting anims and such
-					cent->noFace = qtrue;
-				}
-			}
-			else
-			{
-				cent->noLumbar = qtrue;
-				cent->noFace = qtrue;
-			}
+			CG_UpdateNPCBoneAvailability( cent );
 
 			if (cent->localAnimIndex != -1)
 			{
@@ -13754,6 +13768,7 @@ void CG_ResetPlayerEntity( centity_t *cent )
 		//already set.
 		cent->npcLocalSurfOff = 0;
 		cent->npcLocalSurfOn = 0;
+		CG_UpdateNPCBoneAvailability( cent );
 	}
 	else
 	{
@@ -13824,6 +13839,7 @@ void CG_ResetPlayerEntity( centity_t *cent )
 
 			cent->localAnimIndex = CG_G2SkelForModel(cent->ghoul2);
 			cent->eventAnimIndex = CG_G2EvIndexForModel(cent->ghoul2, cent->localAnimIndex);
+			CG_UpdateNPCBoneAvailability( cent );
 
 			//CG_CopyG2WeaponInstance(cent->currentState.weapon, ci->ghoul2Model);
 			//cent->weapon = cent->currentState.weapon;


### PR DESCRIPTION
The bug: Sentry npcs get spawned and set cent->noLumbar = qtrue, as they have no leg anims, and then humanoids reuses the same npc slot without noLumbar being cleared, causing the legs to not do run animations when the torso runs a different animation, eg swinging the saber