### PR TITLE
[rend2] Fix mergeLeafSurfaces

### DIFF
--- a/shared/rd-rend2/tr_bsp.cpp
+++ b/shared/rd-rend2/tr_bsp.cpp
@@ -3608,8 +3608,6 @@ static void R_MergeLeafSurfaces(world_t *worldData)
 		}
 
 		// create ibo
-		ibo = tr.ibos[tr.numIBOs++] = (IBO_t*)Hunk_Alloc(sizeof(*ibo), h_low);
-		memset(ibo, 0, sizeof(*ibo));
 		numIboIndexes = 0;
 
 		// allocate indexes
@@ -3637,7 +3635,6 @@ static void R_MergeLeafSurfaces(world_t *worldData)
 				*outIboIndexes++ = bspSurf->indexes[k] + bspSurf->firstVert;
 				numIboIndexes++;
 			}
-			break;
 		}
 
 		vboSurf = (srfBspSurface_t *)Hunk_Alloc(sizeof(*vboSurf), h_low);
@@ -3645,7 +3642,6 @@ static void R_MergeLeafSurfaces(world_t *worldData)
 		vboSurf->surfaceType = SF_VBO_MESH;
 
 		vboSurf->vbo = vbo;
-		vboSurf->ibo = ibo;
 
 		vboSurf->numIndexes = numIndexes;
 		vboSurf->numVerts = numVerts;
@@ -3672,14 +3668,11 @@ static void R_MergeLeafSurfaces(world_t *worldData)
 		mergedSurf->cubemapIndex  = surf1->cubemapIndex;
 		mergedSurf->shader        = surf1->shader;
 
-		// finish up the ibo
-		qglGenBuffers(1, &ibo->indexesVBO);
-
-		R_BindIBO(ibo);
-		qglBufferData(GL_ELEMENT_ARRAY_BUFFER, numIboIndexes * sizeof(*iboIndexes), iboIndexes, GL_STATIC_DRAW);
-		R_BindNullIBO();
-
-		GL_CheckErrors();
+		vboSurf->ibo = R_CreateIBO(
+			(byte *)iboIndexes,
+			numIboIndexes * sizeof(glIndex_t),
+			VBO_USAGE_STATIC,
+			va("Merged_%i", i) );
 
    		Z_Free(iboIndexes);
 


### PR DESCRIPTION
A single break; prevented the code to fill the new indices past the first mergable surface. Also using R_CreateIBO now to get debug names.